### PR TITLE
Add router option

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -43,6 +43,11 @@ func MainFlags() []cli.Flag {
 			Value:  "10.1.0.1/24",
 		},
 		&cli.StringFlag{
+			Name:   "router",
+			Usage:  "Sends all packets to this node",
+			EnvVar: "ROUTER",
+		},
+		&cli.StringFlag{
 			Name:   "interface",
 			Usage:  "Interface name",
 			Value:  "edgevpn0",

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -135,6 +135,7 @@ func displayStart(e *edgevpn.EdgeVPN) {
 func cliToOpts(c *cli.Context) []edgevpn.Option {
 	config := c.String("config")
 	address := c.String("address")
+	router := c.String("router")
 	iface := c.String("interface")
 	logLevel := c.String("log-level")
 	libp2plogLevel := c.String("libp2p-log-level")
@@ -179,6 +180,7 @@ func cliToOpts(c *cli.Context) []edgevpn.Option {
 		edgevpn.WithInterfaceMTU(c.Int("mtu")),
 		edgevpn.WithPacketMTU(1420),
 		edgevpn.WithInterfaceAddress(address),
+		edgevpn.WithRouterAddress(router),
 		edgevpn.WithInterfaceName(iface),
 		edgevpn.WithInterfaceType(water.TUN),
 		edgevpn.NetLinkBootstrap(true),

--- a/pkg/edgevpn/config.go
+++ b/pkg/edgevpn/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	Interface        *water.Interface
 	InterfaceName    string
 	InterfaceAddress string
+	RouterAddress    string
 	InterfaceMTU     int
 	MTU              int
 	DeviceType       water.DeviceType

--- a/pkg/edgevpn/options.go
+++ b/pkg/edgevpn/options.go
@@ -53,6 +53,13 @@ func WithInterfaceAddress(i string) func(cfg *Config) error {
 	}
 }
 
+func WithRouterAddress(i string) func(cfg *Config) error {
+	return func(cfg *Config) error {
+		cfg.RouterAddress = i
+		return nil
+	}
+}
+
 func WithInterfaceMTU(i int) func(cfg *Config) error {
 	return func(cfg *Config) error {
 		cfg.InterfaceMTU = i


### PR DESCRIPTION
Hi @mudler, nice project!
This PR adds possibility to optionally set one of the remote nodes as router / gateway and so allows to reach LAN networks behind the router or even use it as default gateway to forward Internet traffic via it.
In short it adds traditional VPN functional in addition to existing mesh functional.

Examples
```bash
edgevpn --address 10.0.3.2/24 --router 10.0.3.1
...
```
Access LAN network 10.0.0.0/24
```
$ ip route add 10.0.0.0/24 dev edgevpn0
$ ping -c 1 10.0.0.1
PING 10.0.0.1 (10.0.0.1) 56(84) bytes of data.
64 bytes from 10.0.0.1: icmp_seq=1 ttl=64 time=7.63 ms
```
Access Internet (remote node should have configured forwarding and NAT)
```
# 52.10.234.17 is the p2p-circuit address of remote node
# 192.168.0.1 is the local router
$ ip route add 52.10.234.17 via 192.168.0.1
$ ip route add default dev edgevpn0 metric 1
```