### PR TITLE
Fixes for DHCP

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -107,19 +107,14 @@ func Main() func(c *cli.Context) error {
 		}
 		o, vpnOpts, ll := cliToOpts(c)
 
+		o = append(o, services.Alive(30*time.Second)...)
 		if c.Bool("dhcp") {
 			address, _, err := net.ParseCIDR(c.String("address"));
 			if err != nil {
 				return err
 			}
 			nodeOpts, vO := vpn.DHCP(ll, 10*time.Second, c.String("lease-dir"), address.String())
-			o = append(
-				append(
-					o,
-					services.Alive(30*time.Second)...,
-				),
-				nodeOpts...,
-			)
+			o = append(o, nodeOpts...,)
 			vpnOpts = append(vpnOpts, vO...)
 		}
 

--- a/pkg/vpn/dhcp.go
+++ b/pkg/vpn/dhcp.go
@@ -45,7 +45,7 @@ func checkDHCPLease(c node.Config, leasedir string) string {
 	return ""
 }
 
-func DHCP(l log.StandardLogger, announcetime time.Duration, leasedir string) ([]node.Option, []Option) {
+func DHCP(l log.StandardLogger, announcetime time.Duration, leasedir string, address string) ([]node.Option, []Option) {
 	ip := make(chan string, 1)
 	return []node.Option{
 			func(cfg *node.Config) error {
@@ -110,7 +110,7 @@ func DHCP(l log.StandardLogger, announcetime time.Duration, leasedir string) ([]
 						// We are lead
 						l.Debug("picking up between", ips)
 
-						wantedIP = utils.NextIP("10.1.0.1", ips)
+						wantedIP = utils.NextIP(address, ips)
 					}
 
 					// Save lease to disk


### PR DESCRIPTION
Hi @mudler !
Here are few changes for new DHCP mode
1) Add separate dhcp flag to be able to change DHCP subnet. Before this change network is hardcoded to 10.1.0.0/24, after this change you run edgevpn as
`edgevpn --dhcp`
to use default 10.1.0.0/24 network
or run 
`edgevpn --address 10.0.2.1/24 --dhcp` 
to change subnet to 10.0.2.0/24
2) Register alive service for nodes with static IP in addition to DHCP nodes. So for example you could run one node with static IP and other with dynamic address configuration will get IP. Prior to this change it wasn't possible, at least 2 nodes were required to have dynamic configuration
```
node A$ edgevpn --address 10.1.0.1/24
...
node B$ edgevpn --dhcp
IP Received 10.1.0.2/24
```