### PR TITLE
routing option: allow mesh and VPN behaviour coexist

### DIFF
--- a/pkg/vpn/vpn.go
+++ b/pkg/vpn/vpn.go
@@ -197,7 +197,9 @@ func handleFrame(mgr streamManager, frame ethernet.Frame, c *Config, n *node.Nod
 
 	dst := dstIP.String()
 	if c.RouterAddress != "" && srcIP.Equal(ip) {
-		dst = c.RouterAddress
+		if _, found := ledger.GetKey(protocol.MachinesLedgerKey, dst); !found {
+			dst = c.RouterAddress
+		}
 	}
 
 	// Query the routing table


### PR DESCRIPTION
Hi @mudler !
This PR allows mesh functionality when router option is used
Access to not know networks go via router, but access to known peers now go directly 