### PR TITLE
Disable low-profile by default

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -172,7 +172,7 @@ var CommonFlags []cli.Flag = []cli.Flag{
 		Usage:  "Enable DHT for peer discovery",
 		EnvVar: "EDGEVPNDHT",
 	},
-	&cli.BoolTFlag{
+	&cli.BoolFlag{
 		Name:   "low-profile",
 		Usage:  "Enable low profile. Lowers connections usage",
 		EnvVar: "EDGEVPNLOWPROFILE",


### PR DESCRIPTION
with new versions seems there is a boost of performance by disabling this by default with new libp2p 0.23