### PR TITLE
Add installation instructions via brew for macos

### DIFF
--- a/docs/content/en/docs/Getting started/_index.md
+++ b/docs/content/en/docs/Getting started/_index.md
@@ -14,6 +14,14 @@ Prerequisites: No dependencies. EdgeVPN releases are statically compiled.
 
 Just grab a release from [the release page on GitHub](https://github.com/mudler/edgevpn/releases). The binaries are statically compiled.
 
+### Via Homebrew on Macos
+
+If you're using homebrew in MacOS, you can use the [edgevpn formula](https://formulae.brew.sh/formula/edgevpn)
+
+```
+brew install edgevpn
+```
+
 
 ### Building EdgeVPN from source
 


### PR DESCRIPTION
I've created a formula in Homebrew to make it simpler to install on macOS

References:

- https://github.com/Homebrew/homebrew-core/pull/165099
- https://formulae.brew.sh/formula/edgevpn