### PR TITLE
Fix IPv6 support on macOS and provide very basic documentation detailing how it can be used

### DIFF
--- a/docs/content/en/docs/Getting started/cli.md
+++ b/docs/content/en/docs/Getting started/cli.md
@@ -78,3 +78,12 @@ Note: Experimental feature!
 Automatic IP negotiation is available since version `0.8.1`.
 
 DHCP can be enabled with `--dhcp` and `--address` can be omitted. If an IP is specfied with `--address` it will be the default IP.
+
+## IPv6 (experimental)
+
+Node: Very experimental feature! Highly unstable!
+
+Very provisional support for IPv6 is available using static addresses only. Currently only one address is supported per interface, dual stack is not available.
+For more information, checkout [issue #15](https://github.com/mudler/edgevpn/issues/15)
+
+IPv6 can be enabled with `--address fd:ed4e::<IP>/64` and `--mtu >1280`.

--- a/pkg/vpn/interface_darwin.go
+++ b/pkg/vpn/interface_darwin.go
@@ -54,7 +54,13 @@ func prepareInterface(c *Config) error {
 
 	// Add the address to the interface. This is not directly possible with the `net` package,
 	// so we use the `ifconfig` command.
-	cmd = exec.Command("ifconfig", iface.Name, "inet", ip.String(), ip.String())
+	if ip.To4() == nil {
+		// IPV6
+		cmd = exec.Command("ifconfig", iface.Name, "inet6", ip.String())
+	} else {
+		// IPv4
+		cmd = exec.Command("ifconfig", iface.Name, "inet", ip.String(), ip.String())
+	}
 	err = cmd.Run()
 	if err != nil {
 		return err


### PR DESCRIPTION
This currently works perfectly if you set the correct flags, but the lack of documentation makes it very difficult to figure out what these are. 

This simple PR is meant to act as a placeholder until the feature is more complete and can be documented more fully.

Ref #15 