### PR TITLE
Add route on macOS

### DIFF
--- a/pkg/vpn/interface_darwin.go
+++ b/pkg/vpn/interface_darwin.go
@@ -39,7 +39,7 @@ func prepareInterface(c *Config) error {
 		return err
 	}
 
-	ip, _, err := net.ParseCIDR(c.InterfaceAddress)
+	ip, ipNet, err := net.ParseCIDR(c.InterfaceAddress)
 	if err != nil {
 		return err
 	}
@@ -63,6 +63,13 @@ func prepareInterface(c *Config) error {
 	// Bring up the interface. This is not directly possible with the `net` package,
 	// so we use the `ifconfig` command.
 	cmd = exec.Command("ifconfig", iface.Name, "up")
+	err = cmd.Run()
+	if err != nil {
+		return err
+	}
+
+	// Add route
+	cmd = exec.Command("route", "-n", "add", "-net", ipNet.String(), ip.String())
 	err = cmd.Run()
 	if err != nil {
 		return err


### PR DESCRIPTION
While trying to communicate between two nodes, I realized that I couldn't ssh into my Linux box from my macOS one. This is because when implementing https://github.com/mudler/edgevpn/pull/161 I didn't have the need for this and missed to realize that it is necessary to also add a route. With this change, the routing table looks like this in an case where the requested address is `10.1.0/24` via `utun20`:

```
netstat -rn | grep 10.1.0
10.1/24            10.1.0.20          UGSc               utun20
10.1.0.20          10.1.0.20          UH                 utun20
```

while previously it only had the one for the specific IP without the range