### PR TITLE
Use a Null connection manager

### DIFF
--- a/pkg/node/connection.go
+++ b/pkg/node/connection.go
@@ -24,6 +24,7 @@ import (
 	internalCrypto "github.com/mudler/edgevpn/pkg/crypto"
 
 	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/connmgr"
 	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -187,10 +188,12 @@ var defaults = []struct {
 	//	fallback: func(cfg *libp2p.Config) bool { return cfg.ResourceManager == nil },
 	//	opt:      libp2p.DefaultResourceManager,
 	//},
-	//{
-	//	fallback: func(cfg *libp2p.Config) bool { return cfg.ConnManager == nil },
-	//	opt:      libp2p.DefaultConnectionManager,
-	//},
+	{
+		fallback: func(cfg *libp2p.Config) bool { return cfg.ConnManager == nil },
+		// Filling the ConnManager is required, even if its a null one as libp2p will call functions of the
+		// libp2p.Config.ConnManager so we need to have it not nil
+		opt: libp2p.ConnectionManager(connmgr.NullConnMgr{}),
+	},
 	{
 		fallback: func(cfg *libp2p.Config) bool { return cfg.MultiaddrResolver == nil },
 		opt:      libp2p.DefaultMultiaddrResolver,


### PR DESCRIPTION
ConnManager needs to exist in the config otherwise if libp2p tries to
access it like here[0], it can panic as its a nil object. In fact, all
the defaults should never be empty as it could lead to accessing nil
references.

This adds the NullManager to the default config it its nil to avoid
panics when libp2p calls functions on it
    
[0] https://github.com/libp2p/go-libp2p/blob/v0.35.2/config/config.go?rgh-link-date=2024-07-10T08%3A58%3A43Z#L336
