### PR TITLE
fix: do not prematurely close channel

### DIFF
--- a/pkg/discovery/dht.go
+++ b/pkg/discovery/dht.go
@@ -164,7 +164,7 @@ func (d *DHT) FindClosePeers(ll log.StandardLogger, onlyStaticRelays bool, stati
 			if !onlyStaticRelays {
 				closestPeers, err := d.GetClosestPeers(ctx, d.PeerID().String())
 				if err != nil {
-					close(peerChan)
+					ll.Debug("Error getting closest peers: ", err)
 				}
 
 				for _, p := range closestPeers {


### PR DESCRIPTION
Fixes https://github.com/mudler/edgevpn/issues/371

No need to close the channel here, we keep handling and flush the buffer