### PR TITLE
chore: adapt to new deprecated methods

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -212,7 +212,7 @@ func Main() func(c *cli.Context) error {
 		ctx := context.Background()
 
 		if c.Bool("transient-conn") {
-			ctx = network.WithUseTransient(ctx, "accept")
+			ctx = network.WithAllowLimitedConn(ctx, "accept")
 		}
 
 		if c.Bool("api") {

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -54,13 +54,11 @@ id = "UA-00000000-0"
 [languages]
 [languages.en]
 title = "EdgeVPN"
-description = "Package manager built from containers"
 languageName ="English"
 # Weight used for sorting.
 weight = 1
 #[languages.it]
 #title = "EdgeVPN"
-#description = "Gestore di pacchetti basato su containers"
 #languageName ="Italian"
 #contentDir = "content/it"
 #time_format_default = "02.01.2006"


### PR DESCRIPTION
This changeset is a small one to make sure we are on par with upstream changes (both for libp2p and docsy)