### PR TITLE
remove replace directive for gosigar dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -182,5 +182,3 @@ require (
 	google.golang.org/protobuf v1.35.1 // indirect
 	lukechampine.com/blake3 v1.3.0 // indirect
 )
-
-replace github.com/elastic/gosigar => github.com/mudler/gosigar v0.14.3-0.20220502202347-34be910bdaaf

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,9 @@ github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDD
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/elastic/gosigar v0.12.0/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
+github.com/elastic/gosigar v0.14.3 h1:xwkKwPia+hSfg9GqrCUKYdId102m9qTJIIr7egmK/uo=
+github.com/elastic/gosigar v0.14.3/go.mod h1:iXRIGg2tLnu7LBdpqzyQfGDEidKCfWcCMS0WKyPWoMs=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=


### PR DESCRIPTION
On arm64 MacOS machine i can't build the project with replaced mudler/gotsigar@v0.14.3... package:
```
# github.com/elastic/gosigar
../../../go/pkg/mod/github.com/mudler/gosigar@v0.14.3-0.20220502202347-34be910bdaaf/sigar_common_darwin.go:473:6: sysctlbyname redeclared in this block
	../../../go/pkg/mod/github.com/mudler/gosigar@v0.14.3-0.20220502202347-34be910bdaaf/sigar_darwin.go:27:6: other declaration of sysctlbyname
../../../go/pkg/mod/github.com/mudler/gosigar@v0.14.3-0.20220502202347-34be910bdaaf/sigar_common_darwin.go:71:19: method Swap.Get already declared at ../../../go/pkg/mod/github.com/mudler/gosigar@v0.14.3-0.20220502202347-34be910bdaaf/sigar_darwin.go:57:19
../../../go/pkg/mod/github.com/mudler/gosigar@v0.14.3-0.20220502202347-34be910bdaaf/sigar_common_darwin.go:86:27: method HugeTLBPages.Get already declared at ../../../go/pkg/mod/github.com/mudler/gosigar@v0.14.3-0.20220502202347-34be910bdaaf/sigar_darwin.go:49:27
../../../go/pkg/mod/github.com/mudler/gosigar@v0.14.3-0.20220502202347-34be910bdaaf/sigar_common_darwin.go:91:18: method Cpu.Get already declared at ../../../go/pkg/mod/github.com/mudler/gosigar@v0.14.3-0.20220502202347-34be910bdaaf/sigar_darwin.go:65:18
../../../go/pkg/mod/github.com/mudler/gosigar@v0.14.3-0.20220502202347-34be910bdaaf/sigar_common_darwin.go:32:26: method LoadAverage.Get already declared at ../../../go/pkg/mod/github.com/mudler/gosigar@v0.14.3-0.20220502202347-34be910bdaaf/sigar_darwin.go:61:23
../../../go/pkg/mod/github.com/mudler/gosigar@v0.14.3-0.20220502202347-34be910bdaaf/sigar_common_darwin.go:45:18: method Mem.Get already declared at ../../../go/pkg/mod/github.com/mudler/gosigar@v0.14.3-0.20220502202347-34be910bdaaf/sigar_darwin.go:45:18
../../../go/pkg/mod/github.com/mudler/gosigar@v0.14.3-0.20220502202347-34be910bdaaf/sigar_common_darwin.go:167:22: method FDUsage.Get already declared at ../../../go/pkg/mod/github.com/mudler/gosigar@v0.14.3-0.20220502202347-34be910bdaaf/sigar_darwin.go:53:22
```

removing replace directive and using upstream gosigar working flawlessly.