### PR TITLE
add support for custom p2p node listen maddrs and dht announce maddrs

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -45,6 +45,16 @@ var CommonFlags []cli.Flag = []cli.Flag{
 		Usage:   "Specify a path to a edgevpn config file",
 		EnvVars: []string{"EDGEVPNCONFIG"},
 	},
+	&cli.StringSliceFlag{
+		Name:    "listen-maddrs",
+		Usage:   "Override default 0.0.0.0 listen multiaddresses",
+		EnvVars: []string{"EDGEVPNLISTENMADDRS"},
+	},
+	&cli.StringSliceFlag{
+		Name:    "dht-announce-maddrs",
+		Usage:   "Override listen-maddrs on DHT announce",
+		EnvVars: []string{"EDGEVPNDHTANNOUNCEMADDRS"},
+	},
 	&cli.StringFlag{
 		Name:    "timeout",
 		Usage:   "Specify a default timeout for connection stream",
@@ -407,6 +417,8 @@ func ConfigFromContext(c *cli.Context) *config.Config {
 	return &config.Config{
 		NetworkConfig:     c.String("config"),
 		NetworkToken:      c.String("token"),
+		ListenMaddrs:      (c.StringSlice("listen-maddrs")),
+		DHTAnnounceMaddrs: stringsToMultiAddr(c.StringSlice("dht-announce-maddrs")),
 		Address:           c.String("address"),
 		Router:            c.String("router"),
 		Interface:         c.String("interface"),


### PR DESCRIPTION
Long story short - i'm trying to join multiple LocalAI nodes which is hosted as docker container images on the vast.ai hosting.   
The problem is - you can't provide the `network_mode: host` in that environment.   
The maximum you can do is expose some port locally for the container, and then the vast.ai service will remap it to some random port on public accessed machine address, like:   
```
[ip4]:13371 -> 8090/tcp
```

To work around that i need to provide to the libp2p the address that is exposed locally to listen to using introduced flag `--listen-maddrs "/ip4/0.0.0.0/tcp/8090"`   
After that, with some patience, using defaults, the node can be actually accessed through the power of auto relay (based on pure luck)   


But we can push that further by announcing on DHT the real public rerouted address using another introduced flag `--dht-announce-maddrs /ip4/[ip4]/tcp/13371`   

Combined both approaches we can successfully reach the node by it's public address right after discovery on the DHT.


The [petals](https://github.com/bigscience-workshop/petals.git) project is using the same approach: https://github.com/bigscience-workshop/petals/blob/22afba627a7eb4fcfe9418c49472c6a51334b8ac/src/petals/cli/run_server.py#L54