### PR TITLE
Improve peerguard

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"net"
 	"os"
@@ -22,6 +23,7 @@ import (
 	"time"
 
 	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/crypto"
 	"github.com/libp2p/go-libp2p/core/metrics"
 	"github.com/libp2p/go-libp2p/core/network"
 
@@ -57,6 +59,10 @@ func MainFlags() []cli.Flag {
 		&cli.BoolFlag{
 			Name:  "b",
 			Usage: "Encodes the new config in base64, so it can be used as a token",
+		},
+		&cli.BoolFlag{
+			Name:  "p",
+			Usage: "Generates a ED25519 private key, converts it to protobuf serialized form, and encodes as base64 string",
 		},
 		&cli.BoolFlag{
 			Name:  "debug",
@@ -154,6 +160,22 @@ func Main() func(c *cli.Context) error {
 				fmt.Println(newData.YAML())
 			}
 
+			os.Exit(0)
+		}
+
+		if c.Bool("p") {
+			// Generates a new protobuf encoded priv key and exit
+			privkey, err := node.GenPrivKey(0)
+			if err != nil {
+				return err
+			}
+
+			protoKey, err := crypto.MarshalPrivateKey(privkey)
+			if err != nil {
+				return err
+			}
+
+			fmt.Printf("Private key: %s\n", base64.StdEncoding.EncodeToString(protoKey))
 			os.Exit(0)
 		}
 		o, vpnOpts, ll := cliToOpts(c)

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -508,32 +508,30 @@ func cliToOpts(c *cli.Context) ([]node.Option, []vpn.Option, *logger.Logger) {
 		} else {
 			nc.Privkey = raw
 		}
-	} else {
 		// Check if we have any privkey identity cached already
-		if c.Bool("privkey-cache") {
-			keyFile := filepath.Join(c.String("privkey-cache-dir"), "privkey")
-			dat, err := os.ReadFile(keyFile)
-			if err == nil && len(dat) > 0 {
-				llger.Info("Reading key from", keyFile)
-				nc.Privkey = dat
-			} else {
-				// generate, write
-				llger.Info("Generating private key and saving it locally for later use in", keyFile)
+	} else if c.Bool("privkey-cache") {
+		keyFile := filepath.Join(c.String("privkey-cache-dir"), "privkey")
+		dat, err := os.ReadFile(keyFile)
+		if err == nil && len(dat) > 0 {
+			llger.Info("Reading key from", keyFile)
+			nc.Privkey = dat
+		} else {
+			// generate, write
+			llger.Info("Generating private key and saving it locally for later use in", keyFile)
 
-				privkey, err := node.GenPrivKey(0)
-				checkErr(err)
+			privkey, err := node.GenPrivKey(0)
+			checkErr(err)
 
-				r, err := crypto.MarshalPrivateKey(privkey)
-				checkErr(err)
+			r, err := crypto.MarshalPrivateKey(privkey)
+			checkErr(err)
 
-				err = os.MkdirAll(c.String("privkey-cache-dir"), 0600)
-				checkErr(err)
+			err = os.MkdirAll(c.String("privkey-cache-dir"), 0600)
+			checkErr(err)
 
-				err = os.WriteFile(keyFile, r, 0600)
-				checkErr(err)
+			err = os.WriteFile(keyFile, r, 0600)
+			checkErr(err)
 
-				nc.Privkey = r
-			}
+			nc.Privkey = r
 		}
 	}
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -14,6 +14,7 @@ limitations under the License.
 package cmd
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -321,6 +322,11 @@ var CommonFlags []cli.Flag = []cli.Flag{
 		Usage:   "Enable peerguard. (Experimental)",
 		EnvVars: []string{"PEERGUARD"},
 	},
+	&cli.StringFlag{
+		Name:    "privkey",
+		Usage:   "Use fixed base64 <- protobuf encoded privkey. (Experimental)",
+		EnvVars: []string{"EDGEVPNPRIVKEY"},
+	},
 	&cli.BoolFlag{
 		Name:    "privkey-cache",
 		Usage:   "Enable privkey caching. (Experimental)",
@@ -495,31 +501,39 @@ func cliToOpts(c *cli.Context) ([]node.Option, []vpn.Option, *logger.Logger) {
 		}
 	}
 
-	// Check if we have any privkey identity cached already
-	if c.Bool("privkey-cache") {
-		keyFile := filepath.Join(c.String("privkey-cache-dir"), "privkey")
-		dat, err := os.ReadFile(keyFile)
-		if err == nil && len(dat) > 0 {
-			llger.Info("Reading key from", keyFile)
-
-			nc.Privkey = dat
+	if c.String("privkey") != "" {
+		raw, err := base64.StdEncoding.DecodeString(c.String("privkey"))
+		if err != nil {
+			checkErr(fmt.Errorf("failed to decode privkey: %v", err))
 		} else {
-			// generate, write
-			llger.Info("Generating private key and saving it locally for later use in", keyFile)
+			nc.Privkey = raw
+		}
+	} else {
+		// Check if we have any privkey identity cached already
+		if c.Bool("privkey-cache") {
+			keyFile := filepath.Join(c.String("privkey-cache-dir"), "privkey")
+			dat, err := os.ReadFile(keyFile)
+			if err == nil && len(dat) > 0 {
+				llger.Info("Reading key from", keyFile)
+				nc.Privkey = dat
+			} else {
+				// generate, write
+				llger.Info("Generating private key and saving it locally for later use in", keyFile)
 
-			privkey, err := node.GenPrivKey(0)
-			checkErr(err)
+				privkey, err := node.GenPrivKey(0)
+				checkErr(err)
 
-			r, err := crypto.MarshalPrivateKey(privkey)
-			checkErr(err)
+				r, err := crypto.MarshalPrivateKey(privkey)
+				checkErr(err)
 
-			err = os.MkdirAll(c.String("privkey-cache-dir"), 0600)
-			checkErr(err)
+				err = os.MkdirAll(c.String("privkey-cache-dir"), 0600)
+				checkErr(err)
 
-			err = os.WriteFile(keyFile, r, 0600)
-			checkErr(err)
+				err = os.WriteFile(keyFile, r, 0600)
+				checkErr(err)
 
-			nc.Privkey = r
+				nc.Privkey = r
+			}
 		}
 	}
 

--- a/config.yml
+++ b/config.yml
@@ -17,4 +17,3 @@ trusted_peer_ids:
 protected_store_key:
   - trustzone
   - trustzoneAuth
-  - initialOwner

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,20 @@
+otp:
+  dht:
+    interval: 360
+    key: YVMwYeeoIJ9yGQeuRNHY3wigEhDEisAPcbt0L30vQ3q
+    length: 43
+  crypto:
+    interval: 360
+    key: 0Yu91JT1WPmWtmmrFD5tWrSzeyhLUVFWyiEXzIezcyz
+    length: 43
+room: k9xRlX6brHxKMAWhGgvsuoiwq4fcNyNtA7JQivZBYm7
+rendezvous: tFMpGqtqtFHckVt62FCklh9xqjTi9upKWCmXNrNBCpL
+mdns: NG8LRHaJTRnR0tbOGgr73oQTZqvKEn0kllXQr5SfKDs
+max_message_size: 20971520
+
+trusted_peer_ids:
+  - 12D3KooWQi1XDFy1Ntv5WXLYJWbuFy1zbXM3F6jc4DUJKtaoZPpC
+protected_store_key:
+  - trustzone
+  - trustzoneAuth
+  - initialOwner

--- a/config_example.yml
+++ b/config_example.yml
@@ -17,4 +17,3 @@ trusted_peer_ids:
 protected_store_key:
   - trustzone
   - trustzoneAuth
-  - initialOwner

--- a/config_example.yml
+++ b/config_example.yml
@@ -1,0 +1,20 @@
+otp:
+  dht:
+    interval: 360
+    key: YVMwYeeoIJ9yGQeuRNHY3wigEhDEisAPcbt0L30vQ3q
+    length: 43
+  crypto:
+    interval: 360
+    key: 0Yu91JT1WPmWtmmrFD5tWrSzeyhLUVFWyiEXzIezcyz
+    length: 43
+room: k9xRlX6brHxKMAWhGgvsuoiwq4fcNyNtA7JQivZBYm7
+rendezvous: tFMpGqtqtFHckVt62FCklh9xqjTi9upKWCmXNrNBCpL
+mdns: NG8LRHaJTRnR0tbOGgr73oQTZqvKEn0kllXQr5SfKDs
+max_message_size: 20971520
+
+trusted_peer_ids:
+  - 12D3KooWQi1XDFy1Ntv5WXLYJWbuFy1zbXM3F6jc4DUJKtaoZPpC
+protected_store_key:
+  - trustzone
+  - trustzoneAuth
+  - initialOwner

--- a/docs/content/en/docs/Concepts/Overview/peerguardian.md
+++ b/docs/content/en/docs/Concepts/Overview/peerguardian.md
@@ -59,7 +59,7 @@ $ curl -X PUT 'http://localhost:8080/api/ledger/trustzoneAuth/ecdsa_1/LS0tLS1CRU
 Now the private key can be used while starting new nodes:
 
 ```bash
-PEERGATE_AUTH="{ 'ecdsa' : { 'private_key': 'LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1JSGNBZ0VCQkVJQkhUZnRSTVZSRmlvaWZrdllhZEE2NXVRQXlSZTJSZHM0MW1UTGZlNlRIT3FBTTdkZW9sak0KZXVPbTk2V0hacEpzNlJiVU1tL3BCWnZZcElSZ0UwZDJjdUdnQndZRks0RUVBQ09oZ1lrRGdZWUFCQUdVWStMNQptUzcvVWVoSjg0b3JieGo3ZmZUMHBYZ09MSzNZWEZLMWVrSTlEWnR6YnZWOUdwMHl6OTB3aVZxajdpMDFVRnhVCnRKbU1lWURIRzBTQkNuVWpDZ0FGT3ByUURpTXBFR2xYTmZ4LzIvdEVySDIzZDNwSytraFdJbUIza01QL2tRNEIKZzJmYnk2cXJpY1dHd3B4TXBXNWxKZVZXUGlkeWJmMSs0cVhPTWdQbmRnPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=' } }"
+PEERGATE_AUTH='{ "ecdsa" : { "private_key": "LS0tLS1CRUdJTiBFQyBQUklWQVRFIEtFWS0tLS0tCk1JSGNBZ0VCQkVJQkhUZnRSTVZSRmlvaWZrdllhZEE2NXVRQXlSZTJSZHM0MW1UTGZlNlRIT3FBTTdkZW9sak0KZXVPbTk2V0hacEpzNlJiVU1tL3BCWnZZcElSZ0UwZDJjdUdnQndZRks0RUVBQ09oZ1lrRGdZWUFCQUdVWStMNQptUzcvVWVoSjg0b3JieGo3ZmZUMHBYZ09MSzNZWEZLMWVrSTlEWnR6YnZWOUdwMHl6OTB3aVZxajdpMDFVRnhVCnRKbU1lWURIRzBTQkNuVWpDZ0FGT3ByUURpTXBFR2xYTmZ4LzIvdEVySDIzZDNwSytraFdJbUIza01QL2tRNEIKZzJmYnk2cXJpY1dHd3B4TXBXNWxKZVZXUGlkeWJmMSs0cVhPTWdQbmRnPT0KLS0tLS1FTkQgRUMgUFJJVkFURSBLRVktLS0tLQo=" } }'
 $ edgevpn --peerguardian --peergate
 ```
 
@@ -88,7 +88,7 @@ $ curl -X PUT 'http://localhost:8080/api/peergate/disable'
 To init a new Trusted network, start nodes with `--peergate-relaxed` and add the neccessary auth keys:
 
 ```bash
-$ edgevpn --peerguardian --peergate --peergate-relaxed
+$ edgevpn --peerguard --peergate --peergate-relaxed
 $ curl -X PUT 'http://localhost:8080/api/ledger/trustzoneAuth/keytype_1/XXX'
 ```
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -482,6 +482,7 @@ func (c Config) ToOpts(l *logger.Logger) ([]node.Option, []vpn.Option, error) {
 			node.WithNetworkService(
 				pg.UpdaterService(dur),
 				pguardian.Challenger(dur, c.PeerGuard.Autocleanup),
+				pguardian.AutoTrust(dur),
 			),
 			node.EnableGenericHub,
 			node.GenericChannelHandlers(pguardian.ReceiveMessage),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -469,7 +469,7 @@ func (c Config) ToOpts(l *logger.Logger) ([]node.Option, []vpn.Option, error) {
 		// Build up the authproviders for the peerguardian
 		aps := []trustzone.AuthProvider{}
 		for ap, providerOpts := range c.PeerGuard.AuthProviders {
-			a, err := authProvider(llger, ap, providerOpts)
+			a, err := AuthProvider(llger, ap, providerOpts)
 			if err != nil {
 				return opts, vpnOpts, fmt.Errorf("invalid authprovider: %w", err)
 			}
@@ -498,7 +498,7 @@ func (c Config) ToOpts(l *logger.Logger) ([]node.Option, []vpn.Option, error) {
 	return opts, vpnOpts, nil
 }
 
-func authProvider(ll log.StandardLogger, s string, opts map[string]interface{}) (trustzone.AuthProvider, error) {
+func AuthProvider(ll log.StandardLogger, s string, opts map[string]interface{}) (trustzone.AuthProvider, error) {
 	switch strings.ToLower(s) {
 	case "ecdsa":
 		pk, exists := opts["private_key"]

--- a/pkg/node/config.go
+++ b/pkg/node/config.go
@@ -76,6 +76,9 @@ type Config struct {
 
 	Sealer    Sealer
 	PeerGater Gater
+
+	TrustedPeerIDS     []string
+	ProtectedStoreKeys []string
 }
 
 type Gater interface {

--- a/pkg/node/connection.go
+++ b/pkg/node/connection.go
@@ -20,6 +20,7 @@ import (
 	"io"
 	mrand "math/rand"
 	"net"
+	"slices"
 
 	internalCrypto "github.com/mudler/edgevpn/pkg/crypto"
 
@@ -251,6 +252,21 @@ func (e *Node) handleEvents(ctx context.Context, inputChannel chan *hub.Message,
 		case m := <-roomMessages:
 			if m == nil {
 				continue
+			}
+
+			// If we have enabled trusted arbiter peers
+			if len(e.config.TrustedPeerIDS) > 0 && e.host.ID().String() != m.SenderID {
+				// If we are not the trusted one
+				if !slices.Contains(e.config.TrustedPeerIDS, e.host.ID().String()) {
+					// If incoming message is not from trusted one
+					if !slices.Contains(e.config.TrustedPeerIDS, m.SenderID) {
+						e.config.Logger.Warnf("%s gated room message from %s - not present in trusted peer IDS", e.host.ID(), m.SenderID)
+						continue
+					} else {
+						// If we a non-trusted peer, and we receive a meesage from the trusted one - disable peerGater
+						peerGater = false
+					}
+				}
 			}
 
 			if peerGater {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -15,9 +15,7 @@ package node
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
-	"os"
 	"slices"
 	"sync"
 	"time"
@@ -131,22 +129,6 @@ func (e *Node) Start(ctx context.Context) error {
 	}
 	ledger.SetTrustedPeerIDS(e.config.TrustedPeerIDS)
 	ledger.SetProtectedStoreKeys(e.config.ProtectedStoreKeys)
-
-	// For testing purposes, can be included into the config opts routine as init known public key
-	if os.Getenv("PEERGATE_PUBLIC") != "" {
-		publicStr := os.Getenv("PEERGATE_PUBLIC")
-		publicMap := map[string]string{}
-
-		err := json.Unmarshal([]byte(publicStr), &publicMap)
-		if err != nil {
-			return fmt.Errorf("error while unmarshaling initial public keys: '%w'", err)
-		}
-
-		for k, v := range publicMap {
-			ledger.Persist(ctx, 5*time.Second, 20*time.Second, protocol.TrustZoneAuthKey, k, v)
-		}
-		ledger.Persist(ctx, 5*time.Second, 20*time.Second, "initialOwner", e.host.ID().String(), "")
-	}
 
 	// Send periodically messages to the channel with our blockchain content
 	ledger.Syncronizer(ctx, e.config.LedgerSyncronizationTime)

--- a/pkg/node/options.go
+++ b/pkg/node/options.go
@@ -259,6 +259,9 @@ type YAMLConnectionConfig struct {
 	Rendezvous     string `yaml:"rendezvous"`
 	MDNS           string `yaml:"mdns"`
 	MaxMessageSize int    `yaml:"max_message_size"`
+
+	TrustedPeerIDS     []string `yaml:"trusted_peer_ids"`
+	ProtectedStoreKeys []string `yaml:"protected_store_keys"`
 }
 
 // Base64 returns the base64 string representation of the connection
@@ -301,6 +304,8 @@ func (y YAMLConnectionConfig) copy(mdns, dht bool, cfg *Config, d *discovery.DHT
 	}
 	cfg.SealKeyLength = y.OTP.Crypto.Length
 	cfg.MaxMessageSize = y.MaxMessageSize
+	cfg.TrustedPeerIDS = y.TrustedPeerIDS
+	cfg.ProtectedStoreKeys = y.ProtectedStoreKeys
 }
 
 const defaultKeyLength = 43

--- a/pkg/trustzone/authprovider/ecdsa/provider.go
+++ b/pkg/trustzone/authprovider/ecdsa/provider.go
@@ -93,6 +93,7 @@ func (e *ECDSA521) Challenger(inTrustZone bool, c node.Config, n *node.Node, b *
 		msg := hub.NewMessage("challenge")
 		msg.Annotations = make(map[string]interface{})
 		msg.Annotations["sigs"] = string(signature)
+		msg.SenderID = n.Host().ID().String()
 		n.PublishMessage(msg)
 		return
 	}

--- a/pkg/trustzone/authprovider/ecdsa/provider.go
+++ b/pkg/trustzone/authprovider/ecdsa/provider.go
@@ -45,13 +45,13 @@ func ECDSA521Provider(ll log.StandardLogger, privkey string) (*ECDSA521, error) 
 // It cycles over all the Trusted zone Auth data ( providers options, not where senders ID are stored)
 // and detects any key with ecdsa prefix. Values are assumed to be string and parsed as pubkeys.
 // The pubkeys are then used to authenticate nodes and verify if any of the pubkeys validates the challenge.
-func (e *ECDSA521) Authenticate(m *hub.Message, c chan *hub.Message, tzdata map[string]blockchain.Data) bool {
+func (e *ECDSA521) Authenticate(m *hub.Message, c chan *hub.Message, tzdata map[string]blockchain.Data) (bool, string) {
 
 	sigs, ok := m.Annotations["sigs"]
 	if !ok {
 		e.logger.Debug("No signature in message", m.Message, m.Annotations)
 
-		return false
+		return false, ""
 	}
 
 	e.logger.Debug("ECDSA auth Received", m)
@@ -67,17 +67,17 @@ func (e *ECDSA521) Authenticate(m *hub.Message, c chan *hub.Message, tzdata map[
 	if len(pubKeys) == 0 {
 		e.logger.Debug("ECDSA auth: No pubkeys to auth against")
 		// no pubkeys to authenticate present in the ledger
-		return false
+		return false, ""
 	}
 	for _, pubkey := range pubKeys {
 		// Try verifying the signature
 		if err := verify([]byte(pubkey), []byte(fmt.Sprint(sigs)), bytes.NewBufferString(m.Message)); err == nil {
 			e.logger.Debug("ECDSA auth: Signature verified")
-			return true
+			return true, pubkey
 		}
 		e.logger.Debug("ECDSA auth: Signature not verified")
 	}
-	return false
+	return false, ""
 }
 
 // Challenger sends ECDSA521 challenges over the public channel if the current node is not in the trusted zone.

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+keys=($(go run main.go peergater ecdsa-genkey | cut -d: -f2- ))
+PRIVKEY=${keys[0]}
+PUBKEY=${keys[1]}
+
+# export EDGEVPNDHTANNOUNCEMADDRS=/ip4/.../tcp/.../p2p/...
+export EDGEVPNCONFIG=~/config.yml
+export EDGEVPNPEERGATEINTERVAL=10
+export PEERGATE=true
+export PEERGUARD=true
+export PEERGATE_AUTOCLEAN=true
+export PEERGATE_AUTH='{ "ecdsa" : { "private_key": "'$PRIVKEY'" } }'
+export PEERGATE_PUBLIC='{ "ecdsa_1": "'$PUBKEY'" }'
+
+# killall main is a bad idea, but that worked on my machine
+sudo -E bash -c "
+  IFACE=\"utun10\" go run main.go api &
+  IFACE=\"utun11\" go run main.go
+  killall main
+"

--- a/test.sh
+++ b/test.sh
@@ -22,7 +22,6 @@ sudo -E bash -c "
   sleep 3
 
   curl -X PUT http://127.0.0.1:8080/api/ledger/trustzoneAuth/ecdsa_client/"$CLIENT_PUBKEY"
-  curl -X PUT http://127.0.0.1:8080/api/ledger/trustzoneAuth/ecdsa_main/"$MAIN_PUBKEY"
 
   export -n EDGEVPNPRIVKEY
   export -n PEERGATE

--- a/test.sh
+++ b/test.sh
@@ -15,14 +15,17 @@ export PEERGATE=true
 export PEERGUARD=true
 export PEERGATE_AUTOCLEAN=true
 export PEERGATE_AUTH='{ "ecdsa" : { "private_key": "'$MAIN_PRIVKEY'" } }'
-export PEERGATE_PUBLIC='{ "ecdsa_main": "'$MAIN_PUBKEY'", "ecdsa_client": "'$CLIENT_PUBKEY'" }'
 
 # killall main is a bad idea, but that worked on my machine
 sudo -E bash -c "
-  IFACE=\"utun10\"  go run main.go &
+  IFACE=\"utun10\" go run main.go api --enable-healthchecks &
   sleep 3
 
+  curl -X PUT http://127.0.0.1:8080/api/ledger/trustzoneAuth/ecdsa_client/"$CLIENT_PUBKEY"
+  curl -X PUT http://127.0.0.1:8080/api/ledger/trustzoneAuth/ecdsa_main/"$MAIN_PUBKEY"
+
   export -n EDGEVPNPRIVKEY
+  export -n PEERGATE
   export PEERGATE_AUTH='{ \"ecdsa\" : { \"private_key\": \""$CLIENT_PRIVKEY"\" } }'
   
   IFACE=\"utun11\" go run main.go

--- a/test.sh
+++ b/test.sh
@@ -1,21 +1,30 @@
 #!/bin/bash
 
-keys=($(go run main.go peergater ecdsa-genkey | cut -d: -f2- ))
-PRIVKEY=${keys[0]}
-PUBKEY=${keys[1]}
+main_keys=($(go run main.go peergater ecdsa-genkey | cut -d: -f2- ))
+client_keys=($(go run main.go peergater ecdsa-genkey | cut -d: -f2- ))
+MAIN_PRIVKEY=${main_keys[0]}
+MAIN_PUBKEY=${main_keys[1]}
+CLIENT_PRIVKEY=${client_keys[0]}
+CLIENT_PUBKEY=${client_keys[1]}
 
 # export EDGEVPNDHTANNOUNCEMADDRS=/ip4/.../tcp/.../p2p/...
-export EDGEVPNCONFIG=~/config.yml
+export EDGEVPNCONFIG=config.yml
 export EDGEVPNPEERGATEINTERVAL=10
+export EDGEVPNPRIVKEY='CAESQOV82ydHYcTFqyjf6fE6Zrdr9aH97GwGODEWm9HmELv73T55KPBrW5n3D29Df7b+DjH1zVzqUa1cgpTBHiEBdgk='
 export PEERGATE=true
 export PEERGUARD=true
 export PEERGATE_AUTOCLEAN=true
-export PEERGATE_AUTH='{ "ecdsa" : { "private_key": "'$PRIVKEY'" } }'
-export PEERGATE_PUBLIC='{ "ecdsa_1": "'$PUBKEY'" }'
+export PEERGATE_AUTH='{ "ecdsa" : { "private_key": "'$MAIN_PRIVKEY'" } }'
+export PEERGATE_PUBLIC='{ "ecdsa_main": "'$MAIN_PUBKEY'", "ecdsa_client": "'$CLIENT_PUBKEY'" }'
 
 # killall main is a bad idea, but that worked on my machine
 sudo -E bash -c "
-  IFACE=\"utun10\" go run main.go api &
+  IFACE=\"utun10\"  go run main.go &
+  sleep 3
+
+  export -n EDGEVPNPRIVKEY
+  export PEERGATE_AUTH='{ \"ecdsa\" : { \"private_key\": \""$CLIENT_PRIVKEY"\" } }'
+  
   IFACE=\"utun11\" go run main.go
   killall main
 "


### PR DESCRIPTION
Hello there!

For our LocalAI P2P experiments we need to have an ability to authenticate the machines in the P2P network and invalidate them if needed as well.

I have tested the peerguard(-ian) capabilities, and found out that autoclean is broken (or i didn't get it), docs have wrong flag "--peerguardian vs. --peerguard" and PEERGATE_AUTH had wrong quotes, which leads to error in marshaling it as json.

The autoclean part is now kicks the peers that is not connected to MessageHub as it written in the docs and comments, as well it is now aware of self peerID, since ListPeers() didn't returns the self peerID, and we have constant kicking result, where trustzone data becomes unconsistent.
Also, the Authenticate now stores the pubkey which peer used to authenticate, so that way if we delete the pubkey - that user will be kicked from the trustzone.

There are also little testing script i used, which i include for now, since i want to know if i can miss something in the way of testing.

UPD:
Since we don't have a proper ledger with PoW, long-term block storage __with__ ability to retrieve the full chain and just swapping current block if it matches verifier - i had to do some tricks:
 - for now, the trusted peer ID list can be 'hardened' in the VPN config, instead of doing so in genesis block
 - we can specify which buckets are write protected in the VPN config too
 - if trusted peer ID list in config is not empty - the non-matching peers for that list didn't listen to anything, but trusted ones from the start
 - the non-matching peers also didn't verify the blocks at all, just eating what trusted peer provides, so that way they can join later and didn't get desync
 - each storage write is now checked against trusted peer ids and protected keys list, skipping updates with unauthorized write to protected keys (for example, trustzoneAuth and trustzone) 
 - there are new -p flag for generating protobuf serialized -> base64 encoded key, which can be used with EDGEVPNPRIVKEY env variable to make fixed peerID somewhat easier to handle, instead of using of caching into the file

I know, that this is going against decentralized VPN idea, but as part of LocalAI project with need of one-to-many authorized access current implementation of edgevpn is incapable to provide secure authorization mechanism without either complex PoW and proper ledger implementations, or without tricks to create some peers absolutely authoritarian    

This PR is a draft, and i'm waiting for the feedback!
Thanks in advance!

https://github.com/user-attachments/assets/197eff65-fc28-40cf-9555-2cb6146e930a



