### PR TITLE
feat: Add riscv64 architecture support

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,7 @@ builds:
       - arm
       - 386
       - arm64
+      - riscv64
     ignore:
       - goos: windows
         goarch: arm


### PR DESCRIPTION
- Added `riscv64` to the list of supported architectures in .goreleaser.yml
- This change enables building and releasing binaries for the RISC-V 64-bit architecture