### PR TITLE
Fix typo --peerguardian flag in docs

### DIFF
--- a/docs/content/en/docs/Concepts/Overview/peerguardian.md
+++ b/docs/content/en/docs/Concepts/Overview/peerguardian.md
@@ -15,7 +15,7 @@ Experimental feature!
 
 PeerGuardian is a mechanism to prevent unauthorized access to the network if tokens are leaked or either revoke network access.
 
-In order to enable it, start edgevpn nodes adding the `--peerguradian` flag.
+In order to enable it, start edgevpn nodes adding the `--peerguardian` flag.
 
 ```bash
 edgevpn --peerguardian


### PR DESCRIPTION
Changed one instance of `--peerguradian` to `--peerguardian`