### PR TITLE
fix(blockchain): resolve equal-index ledger split-brain with a deterministic tie-break

### DIFF
--- a/pkg/blockchain/ledger.go
+++ b/pkg/blockchain/ledger.go
@@ -124,7 +124,20 @@ func (l *Ledger) Update(f *Ledger, h *hub.Message, c chan *hub.Message) (err err
 	}
 
 	l.Lock()
-	if block.Index > l.blockchain.Len() {
+	// Adopt the incoming block when it is higher (height wins), or — on an
+	// exact height tie — when its hash sorts higher. The tie-break is what lets
+	// two ledgers that independently climbed to the same index with different
+	// data converge: with `>` alone each node rejects the other's equal-height
+	// block forever (split-brain — e.g. two peers that start simultaneously and
+	// advertise in lockstep). The comparison is deterministic, so every node
+	// picks the same winner and it cannot flip-flop; the loser re-adds its own
+	// data on the next Announce, which raises the index and is then adopted via
+	// the height rule. This is still a whole-block replace (not a merge), so
+	// deletions keep propagating through a higher index and nothing previously
+	// deleted is resurrected.
+	last := l.blockchain.Last()
+	if block.Index > last.Index ||
+		(block.Index == last.Index && block.Hash > last.Hash) {
 		l.blockchain.Add(*block)
 	}
 	l.Unlock()

--- a/pkg/blockchain/ledger_test.go
+++ b/pkg/blockchain/ledger_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright © 2021-2022 Ettore Di Giacinto <mudler@mocaccino.org>
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blockchain
+
+import (
+	"encoding/json"
+	"io"
+	"testing"
+
+	"github.com/mudler/edgevpn/pkg/hub"
+)
+
+// msgFor wraps a ledger's last block into the wire form Update expects
+// (gzip-compressed JSON), mirroring what writeData broadcasts.
+func msgFor(l *Ledger) *hub.Message {
+	bb, _ := json.Marshal(l.LastBlock())
+	return hub.NewMessage(compress(bb).String())
+}
+
+// TestUpdateEqualIndexTieBreak guards the fix for the equal-index split-brain:
+// two ledgers that independently climb to the same index with different data
+// (e.g. two peers that start simultaneously and advertise in lockstep) must
+// converge on exchange instead of rejecting each other forever.
+func TestUpdateEqualIndexTieBreak(t *testing.T) {
+	a := New(io.Discard, &MemoryStore{})
+	b := New(io.Discard, &MemoryStore{})
+
+	a.Add("nodes", map[string]interface{}{"a": "1"})
+	b.Add("nodes", map[string]interface{}{"b": "1"})
+
+	// Precondition: same height, different blocks — the deadlock scenario.
+	if a.LastBlock().Index != b.LastBlock().Index {
+		t.Fatalf("precondition: expected equal index, got %d and %d",
+			a.LastBlock().Index, b.LastBlock().Index)
+	}
+	if a.LastBlock().Hash == b.LastBlock().Hash {
+		t.Fatal("precondition: expected the two blocks to differ")
+	}
+
+	// Each node receives the other's equal-index block.
+	if err := a.Update(a, msgFor(b), nil); err != nil {
+		t.Fatal(err)
+	}
+	if err := b.Update(b, msgFor(a), nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// Deterministic tie-break: both must now hold the same (higher-hash) block,
+	// not their own divergent ones.
+	if a.LastBlock().Hash != b.LastBlock().Hash {
+		t.Fatalf("tie-break did not converge: a=%s b=%s",
+			a.LastBlock().Hash, b.LastBlock().Hash)
+	}
+}
+
+// TestUpdateHigherIndexStillWins ensures the height rule (and thus deletion
+// propagation, which works by raising the index) is unchanged by the tie-break.
+func TestUpdateHigherIndexStillWins(t *testing.T) {
+	a := New(io.Discard, &MemoryStore{})
+	b := New(io.Discard, &MemoryStore{})
+
+	// b climbs higher than a.
+	a.Add("nodes", map[string]interface{}{"a": "1"})
+	b.Add("nodes", map[string]interface{}{"b": "1"})
+	b.Add("nodes", map[string]interface{}{"b": "2"})
+
+	if b.LastBlock().Index <= a.LastBlock().Index {
+		t.Fatalf("precondition: expected b higher than a, got %d and %d",
+			b.LastBlock().Index, a.LastBlock().Index)
+	}
+
+	// a receives b's higher block and must adopt it regardless of hash order.
+	if err := a.Update(a, msgFor(b), nil); err != nil {
+		t.Fatal(err)
+	}
+	if a.LastBlock().Hash != b.LastBlock().Hash {
+		t.Fatal("higher-index block was not adopted")
+	}
+}

--- a/pkg/blockchain/ledger_test.go
+++ b/pkg/blockchain/ledger_test.go
@@ -28,18 +28,47 @@ func msgFor(l *Ledger) *hub.Message {
 	return hub.NewMessage(compress(bb).String())
 }
 
-// TestUpdateEqualIndexTieBreak guards the fix for the equal-index split-brain:
-// two ledgers that independently climb to the same index with different data
-// (e.g. two peers that start simultaneously and advertise in lockstep) must
-// converge on exchange instead of rejecting each other forever.
-func TestUpdateEqualIndexTieBreak(t *testing.T) {
+// announce mimics one AnnounceUpdate tick: (re)write our own key only if it is
+// not already the current value. This is what each node does periodically and
+// is what lets the loser of a tie-break re-introduce the data it dropped when
+// it adopted the peer's block.
+func announce(l *Ledger, key string) {
+	if v, ok := l.CurrentData()["nodes"][key]; ok && string(v) == `"1"` {
+		return
+	}
+	l.Add("nodes", map[string]interface{}{key: "1"})
+}
+
+func hasKeys(l *Ledger, keys ...string) bool {
+	nodes := l.CurrentData()["nodes"]
+	for _, k := range keys {
+		if _, ok := nodes[k]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// TestUpdateEqualIndexConvergesToUnion is the regression guard for the
+// equal-index split-brain. Two ledgers independently reach the same index with
+// different data (e.g. two peers booted simultaneously, each having advertised
+// once). It asserts the full outcome that matters: after a few exchange +
+// re-announce rounds BOTH ledgers hold BOTH advertisements and agree on the
+// same block.
+//
+// Note the intermediate state: a single Update only makes the loser adopt the
+// winner's block (the loser's key is momentarily gone). The union is reached on
+// the next announce — the loser re-adds its key, Add unions it onto the current
+// (winner's) storage at a higher index, and the winner adopts that via height.
+func TestUpdateEqualIndexConvergesToUnion(t *testing.T) {
 	a := New(io.Discard, &MemoryStore{})
 	b := New(io.Discard, &MemoryStore{})
 
 	a.Add("nodes", map[string]interface{}{"a": "1"})
 	b.Add("nodes", map[string]interface{}{"b": "1"})
 
-	// Precondition: same height, different blocks — the deadlock scenario.
+	// Precondition: same height, different blocks — the deadlock scenario that
+	// `>`-only rejection could never resolve.
 	if a.LastBlock().Index != b.LastBlock().Index {
 		t.Fatalf("precondition: expected equal index, got %d and %d",
 			a.LastBlock().Index, b.LastBlock().Index)
@@ -48,7 +77,19 @@ func TestUpdateEqualIndexTieBreak(t *testing.T) {
 		t.Fatal("precondition: expected the two blocks to differ")
 	}
 
-	// Each node receives the other's equal-index block.
+	// Drive a few reconcile rounds (exchange, then each re-announces its own
+	// key). Convergence is reached well within this; extra rounds are no-ops.
+	for i := 0; i < 5; i++ {
+		if err := a.Update(a, msgFor(b), nil); err != nil {
+			t.Fatal(err)
+		}
+		if err := b.Update(b, msgFor(a), nil); err != nil {
+			t.Fatal(err)
+		}
+		announce(a, "a")
+		announce(b, "b")
+	}
+	// Final exchange so both observe the latest block.
 	if err := a.Update(a, msgFor(b), nil); err != nil {
 		t.Fatal(err)
 	}
@@ -56,10 +97,14 @@ func TestUpdateEqualIndexTieBreak(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Deterministic tie-break: both must now hold the same (higher-hash) block,
-	// not their own divergent ones.
+	if !hasKeys(a, "a", "b") {
+		t.Fatalf("node a missing an advertisement: %+v", a.CurrentData()["nodes"])
+	}
+	if !hasKeys(b, "a", "b") {
+		t.Fatalf("node b missing an advertisement: %+v", b.CurrentData()["nodes"])
+	}
 	if a.LastBlock().Hash != b.LastBlock().Hash {
-		t.Fatalf("tie-break did not converge: a=%s b=%s",
+		t.Fatalf("ledgers did not converge on the same block: a=%s b=%s",
 			a.LastBlock().Hash, b.LastBlock().Hash)
 	}
 }


### PR DESCRIPTION
Ledger.Update adopted a peer block only when `block.Index > Len()` (strict greater). Two ledgers that independently climb to the same index with different data then reject each other forever: each keeps its own block and never sees the other's. This happens whenever peers start simultaneously and advertise in lockstep — the index plateaus at the same height on both sides (AnnounceUpdate only writes on change), so neither ever gets ahead.

Observed via Kairos p2p auto-clustering with two nodes booted together: the libp2p tunnel and connectivity were fully bidirectional (ping both ways over the VPN overlay), yet the elected leader's ledger view stayed empty — it never received the follower's advertisement, so it never assigned a role and the cluster never formed.

Fix: on an exact height tie, adopt the block whose hash sorts higher. The comparison is deterministic, so every node picks the same winner and it cannot flip-flop; the loser re-adds its own data on the next Announce, which raises the index and is then adopted via the normal height rule, converging the ledgers. This is still a whole-block replace (not a bucket merge), so deletions keep propagating through a higher index and nothing previously deleted is resurrected. Behaviour for the strictly-higher case is unchanged.

Adds blockchain ledger tests covering the equal-index tie-break and the unchanged higher-index-wins path.