### PR TITLE
feat: improve pubsub reliability and NAT detection for small clusters

### DIFF
--- a/pkg/hub/hub.go
+++ b/pkg/hub/hub.go
@@ -40,6 +40,7 @@ type MessageHub struct {
 	keyLength          int
 	interval           int
 	joinPublic         bool
+	directPeers        []peer.AddrInfo
 
 	ctxCancel                context.CancelFunc
 	Messages, PublicMessages chan *Message
@@ -48,9 +49,24 @@ type MessageHub struct {
 // roomBufSize is the number of incoming messages to buffer for each topic.
 const roomBufSize = 128
 
-func NewHub(otp string, maxsize, keyLength, interval int, joinPublic bool) *MessageHub {
-	return &MessageHub{otpKey: otp, maxsize: maxsize, keyLength: keyLength, interval: interval,
+// Option configures a MessageHub at construction time.
+type Option func(*MessageHub)
+
+// WithDirectPeers pins peers as gossipsub direct peers — the router holds a
+// persistent connection to each and bypasses mesh negotiation for them, which
+// makes pubsub delivery reliable to known/bootstrap peers even when the mesh
+// (e.g. on a 2-node cluster) hasn't reached its target size.
+func WithDirectPeers(peers []peer.AddrInfo) Option {
+	return func(m *MessageHub) { m.directPeers = peers }
+}
+
+func NewHub(otp string, maxsize, keyLength, interval int, joinPublic bool, opts ...Option) *MessageHub {
+	m := &MessageHub{otpKey: otp, maxsize: maxsize, keyLength: keyLength, interval: interval,
 		Messages: make(chan *Message, roomBufSize), PublicMessages: make(chan *Message, roomBufSize), joinPublic: joinPublic}
+	for _, o := range opts {
+		o(m)
+	}
+	return m
 }
 
 func (m *MessageHub) topicKey(salts ...string) string {
@@ -72,8 +88,28 @@ func (m *MessageHub) joinRoom(host host.Host) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	m.ctxCancel = cancel
 
-	// create a new PubSub service using the GossipSub router
-	ps, err := pubsub.NewGossipSub(ctx, host, pubsub.WithMaxMessageSize(m.maxsize))
+	// create a new PubSub service using the GossipSub router.
+	//
+	// FloodPublish makes the publisher flood messages to ALL connected peers
+	// rather than only to its mesh — important for small clusters (2-3 nodes)
+	// where the gossipsub mesh sits below its low-watermark and standard
+	// mesh-only delivery becomes unreliable / asymmetric.
+	//
+	// PeerExchange lets gossipsub peers gossip about each other, which helps
+	// recover from one-way mesh links and from peer churn.
+	//
+	// DirectPeers (when set, typically from bootstrap peers) pins specific
+	// peers as always-connected, mesh-bypass delivery targets — guaranteeing
+	// publication reaches them.
+	psOpts := []pubsub.Option{
+		pubsub.WithMaxMessageSize(m.maxsize),
+		pubsub.WithFloodPublish(true),
+		pubsub.WithPeerExchange(true),
+	}
+	if len(m.directPeers) > 0 {
+		psOpts = append(psOpts, pubsub.WithDirectPeers(m.directPeers))
+	}
+	ps, err := pubsub.NewGossipSub(ctx, host, psOpts...)
 	if err != nil {
 		return err
 	}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -23,7 +23,9 @@ import (
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/network"
+	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/p2p/net/conngater"
+	multiaddr "github.com/multiformats/go-multiaddr"
 
 	"github.com/mudler/edgevpn/pkg/crypto"
 	protocol "github.com/mudler/edgevpn/pkg/protocol"
@@ -53,6 +55,7 @@ const defaultChanSize = 3000
 var defaultLibp2pOptions = []libp2p.Option{
 	libp2p.EnableNATService(),
 	libp2p.NATPortMap(),
+	libp2p.EnableAutoNATv2(),
 }
 
 func New(p ...Option) (*Node, error) {
@@ -175,7 +178,14 @@ func (e *Node) startNetwork(ctx context.Context) error {
 	// Hub rotates within sealkey interval.
 	// this time length should be enough to make room for few block exchanges. This is ideally on minutes (10, 20, etc. )
 	// it makes sure that if a bruteforce is attempted over the encrypted messages, the real key is not exposed.
-	e.MessageHub = hub.NewHub(e.config.RoomName, e.config.MaxMessageSize, e.config.SealKeyLength, e.config.SealKeyInterval, e.config.GenericHub)
+	//
+	// Bootstrap peers double as gossipsub direct peers so pubsub delivery to
+	// them is guaranteed regardless of mesh state.
+	hubOpts := []hub.Option{}
+	if directPeers := bootstrapAddrInfos(e.config.DiscoveryBootstrapPeers); len(directPeers) > 0 {
+		hubOpts = append(hubOpts, hub.WithDirectPeers(directPeers))
+	}
+	e.MessageHub = hub.NewHub(e.config.RoomName, e.config.MaxMessageSize, e.config.SealKeyLength, e.config.SealKeyInterval, e.config.GenericHub, hubOpts...)
 
 	for _, sd := range e.config.ServiceDiscovery {
 		if err := sd.Run(e.config.Logger, ctx, host); err != nil {
@@ -194,6 +204,21 @@ func (e *Node) startNetwork(ctx context.Context) error {
 
 	e.config.Logger.Debug("Network started")
 	return nil
+}
+
+// bootstrapAddrInfos resolves a bootstrap address list into peer.AddrInfo
+// values. Entries without an embedded /p2p/<id> component (and therefore not
+// useful as gossipsub direct peers) are skipped.
+func bootstrapAddrInfos(addrs []multiaddr.Multiaddr) []peer.AddrInfo {
+	infos := make([]peer.AddrInfo, 0, len(addrs))
+	for _, a := range addrs {
+		pi, err := peer.AddrInfoFromP2pAddr(a)
+		if err != nil {
+			continue
+		}
+		infos = append(infos, *pi)
+	}
+	return infos
 }
 
 // PublishMessage publishes a message to the generic channel (if enabled)


### PR DESCRIPTION
Three additions that together address asymmetric / one-way gossipsub delivery seen on small (2-3 node) overlay networks where the default gossipsub mesh sits below its low-watermark and AutoNAT v1 cannot reach a stable reachability verdict:

  * libp2p AutoNAT v2 is now in defaultLibp2pOptions. v1 needs >=3 peers to give a stable answer, leaving 2-peer clusters stuck in Unknown reachability and degrading downstream behaviour (relay selection, hole punching, identify). v2 produces a verdict from a single peer.

  * Gossipsub now uses FloodPublish + PeerExchange by default. FloodPublish has the publisher flood to ALL connected peers rather than just mesh peers; in a 2-node network the mesh sits at 1 entry (Dlo=4), well below the healthy-mesh threshold, and standard mesh-only delivery becomes unreliable. PeerExchange lets peers gossip about each other and helps recover from one-way mesh links.

  * When bootstrap peers are configured, they are passed to gossipsub as DirectPeers so the router holds a persistent connection and bypasses mesh negotiation when delivering to them — guaranteeing publication reaches known/seed peers regardless of mesh state.

The hub.NewHub signature gains a variadic Option parameter so callers can opt in to direct-peer pinning without forcing the dependency into the hub package's API. node.startNetwork is the only in-tree caller and wires bootstrap peers through automatically.