### PR TITLE
feat(api): harden local API unix socket listener

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -26,7 +26,9 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/libp2p/go-libp2p/core/metrics"
@@ -116,17 +118,97 @@ func parseOctal(s string) (uint32, error) {
 	return n, nil
 }
 
-// listenUnix creates the API unix socket listener. It removes a
-// stale socket file left over from a previous (crashed) run and then
+// systemdSocketListener returns a unix listener inherited from systemd
+// (LISTEN_FDS/LISTEN_PID), if any. nil, nil means "no socket activation
+// in effect" — the caller should fall through to its normal listen path.
+//
+// Inheriting the listener is the right path for the operator workflow
+// where a .socket unit declares the path, user, group and mode and
+// systemd hands the already-bound FD to the service. In that case we
+// must NOT touch the underlying socket file (its ownership and perms
+// are systemd's responsibility) and we must NOT chmod after the fact
+// (the kernel mode already came from the .socket unit).
+//
+// Reference: sd_listen_fds(3). The convention is FD 3 for the first
+// inherited socket and LISTEN_FDS counts how many are present. We only
+// support a single API listener so we accept LISTEN_FDS=1 strictly.
+func systemdSocketListener() (net.Listener, error) {
+	pidEnv := os.Getenv("LISTEN_PID")
+	fdsEnv := os.Getenv("LISTEN_FDS")
+	if pidEnv == "" || fdsEnv == "" {
+		return nil, nil
+	}
+	pid, err := strconv.Atoi(pidEnv)
+	if err != nil {
+		return nil, fmt.Errorf("invalid LISTEN_PID %q: %w", pidEnv, err)
+	}
+	if pid != os.Getpid() {
+		// systemd-managed FDs are addressed to a specific PID;
+		// if it isn't us, treat the env as not present.
+		return nil, nil
+	}
+	fds, err := strconv.Atoi(fdsEnv)
+	if err != nil {
+		return nil, fmt.Errorf("invalid LISTEN_FDS %q: %w", fdsEnv, err)
+	}
+	if fds != 1 {
+		return nil, fmt.Errorf("LISTEN_FDS=%d, expected exactly 1 (only the API socket can be passed)", fds)
+	}
+	// First inherited FD is always 3 (after stdin/stdout/stderr).
+	const firstFD = 3
+	// Don't leak the FD as O_CLOEXEC-off to children spawned later.
+	syscall.CloseOnExec(firstFD)
+	f := os.NewFile(uintptr(firstFD), "systemd-edgevpn-api-socket")
+	if f == nil {
+		return nil, fmt.Errorf("could not wrap inherited fd %d", firstFD)
+	}
+	l, err := net.FileListener(f)
+	// FileListener dups the fd; close ours so we don't keep it open twice.
+	f.Close()
+	if err != nil {
+		return nil, fmt.Errorf("net.FileListener(fd=%d): %w", firstFD, err)
+	}
+	return l, nil
+}
+
+// unixSocketInUse probes whether something is already serving on the
+// socket at path. A successful connect — even an immediate hangup —
+// means a listener is present and we should refuse to clobber it. We
+// treat ECONNREFUSED as "stale socket file from a crashed previous
+// run" and any other dial error conservatively as "in use" so we
+// never unlink a working socket on a flaky filesystem.
+func unixSocketInUse(path string) bool {
+	c, err := net.DialTimeout("unix", path, 250*time.Millisecond)
+	if err == nil {
+		c.Close()
+		return true
+	}
+	// errors.Is(err, syscall.ECONNREFUSED) is the only signal we'll
+	// accept as "definitively not in use".
+	return !errors.Is(err, syscall.ECONNREFUSED)
+}
+
+// listenUnix creates the API unix socket listener. It only removes a
+// stale socket file (one whose owning process is gone) and then
 // tightens permissions before any client can connect — chmod must
 // happen between Listen and the first Accept to close the window
 // where the kernel-default mode is observable.
+//
+// If the socket is currently being served, listenUnix refuses to
+// touch it — this protects against a second edgevpn racing into a
+// path already owned by a running instance, and against an operator
+// who pre-created the socket file (e.g. via a systemd .socket unit
+// without activation, or `install -m 0660 -o edgevpn`) and intends
+// edgevpn to use what's there. For full systemd socket-activation
+// support, see systemdSocketListener which is invoked by API() before
+// this function ever runs.
 func listenUnix(path string) (net.Listener, error) {
-	// Best-effort removal: ignore "not exist" but surface anything
-	// else so we do not silently bind on top of a non-socket file.
 	if fi, err := os.Lstat(path); err == nil {
 		if fi.Mode()&os.ModeSocket == 0 {
 			return nil, fmt.Errorf("refusing to remove non-socket file at %s", path)
+		}
+		if unixSocketInUse(path) {
+			return nil, fmt.Errorf("socket %s is already in use by another process", path)
 		}
 		if err := os.Remove(path); err != nil {
 			return nil, fmt.Errorf("remove stale socket %s: %w", path, err)
@@ -152,12 +234,30 @@ func API(ctx context.Context, l string, defaultInterval, timeout time.Duration, 
 
 	ec := echo.New()
 
-	var unixSocketPath string
+	var (
+		unixSocketPath  string
+		ownsSocketFile  bool // true iff WE created the file; false for systemd-passed FDs
+	)
 	if strings.HasPrefix(l, UnixSocketScheme) {
 		unixSocketPath = strings.TrimPrefix(l, UnixSocketScheme)
-		unixListener, err := listenUnix(unixSocketPath)
+		// Honour systemd socket activation first: if the operator
+		// declared a .socket unit, systemd has already created and
+		// bound the socket with the user/group/mode they want, and
+		// passed us its FD. Inherit that listener verbatim — do NOT
+		// touch the underlying file. systemdSocketListener returns
+		// (nil, nil) when no activation is in effect, in which case
+		// we fall through to listenUnix and manage the socket file
+		// ourselves.
+		unixListener, err := systemdSocketListener()
 		if err != nil {
-			return err
+			return fmt.Errorf("systemd socket activation: %w", err)
+		}
+		if unixListener == nil {
+			unixListener, err = listenUnix(unixSocketPath)
+			if err != nil {
+				return err
+			}
+			ownsSocketFile = true
 		}
 		ec.Listener = unixListener
 	}
@@ -429,11 +529,12 @@ func API(ctx context.Context, l string, defaultInterval, timeout time.Duration, 
 
 	startErr := ec.Start(l)
 
-	// Always remove the socket on exit — a leftover file would block
-	// the next startup with "address already in use" until listenUnix
-	// reaps it, and leaving sockets around after the process is gone
-	// is generally a footgun for orchestration tooling.
-	if unixSocketPath != "" {
+	// Remove the socket on exit only when we own the file. With
+	// systemd socket activation the .socket unit owns the path
+	// (permissions, ownership, lifecycle) and systemd is responsible
+	// for cleanup; unlinking it from here would break the next
+	// activation cycle.
+	if ownsSocketFile && unixSocketPath != "" {
 		_ = os.Remove(unixSocketPath)
 	}
 

--- a/api/api.go
+++ b/api/api.go
@@ -18,11 +18,13 @@ package api
 import (
 	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"io/fs"
 	"net"
 	"net/http"
 	_ "net/http/pprof"
+	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -67,7 +69,82 @@ const (
 	MetricsURL    = "/api/metrics"
 	PeerstoreURL  = "/api/peerstore"
 	PeerGateURL   = "/api/peergate"
+
+	// UnixSocketScheme is the URI prefix that selects a unix domain
+	// socket listener for the API instead of a TCP address.
+	UnixSocketScheme = "unix://"
+
+	// defaultUnixSocketMode is the file mode applied to API unix
+	// sockets when none is supplied via the APILISTENUNIXMODE env var.
+	// 0660 lets the owner and group communicate with the API and
+	// blocks every other process on the host, which is the right
+	// default for a hardened local control plane.
+	defaultUnixSocketMode os.FileMode = 0o660
 )
+
+// unixSocketMode resolves the file mode that should be applied to
+// the API socket. APILISTENUNIXMODE is interpreted as an octal value
+// (e.g. "0600"); anything unparseable falls back to defaultUnixSocketMode
+// so a typo cannot accidentally widen permissions.
+func unixSocketMode() os.FileMode {
+	v := strings.TrimSpace(os.Getenv("APILISTENUNIXMODE"))
+	if v == "" {
+		return defaultUnixSocketMode
+	}
+	// Accept either "0600" or "600" forms.
+	parsed, err := parseOctal(v)
+	if err != nil {
+		return defaultUnixSocketMode
+	}
+	return os.FileMode(parsed) & os.ModePerm
+}
+
+func parseOctal(s string) (uint32, error) {
+	if s == "" {
+		return 0, errors.New("empty mode")
+	}
+	var n uint32
+	// Strip an optional leading "0" / "0o" so callers can write the
+	// usual unix shorthand without us forcing a specific notation.
+	s = strings.TrimPrefix(strings.TrimPrefix(s, "0o"), "0O")
+	for _, r := range s {
+		if r < '0' || r > '7' {
+			return 0, fmt.Errorf("invalid octal digit %q", r)
+		}
+		n = n<<3 | uint32(r-'0')
+	}
+	return n, nil
+}
+
+// listenUnix creates the API unix socket listener. It removes a
+// stale socket file left over from a previous (crashed) run and then
+// tightens permissions before any client can connect — chmod must
+// happen between Listen and the first Accept to close the window
+// where the kernel-default mode is observable.
+func listenUnix(path string) (net.Listener, error) {
+	// Best-effort removal: ignore "not exist" but surface anything
+	// else so we do not silently bind on top of a non-socket file.
+	if fi, err := os.Lstat(path); err == nil {
+		if fi.Mode()&os.ModeSocket == 0 {
+			return nil, fmt.Errorf("refusing to remove non-socket file at %s", path)
+		}
+		if err := os.Remove(path); err != nil {
+			return nil, fmt.Errorf("remove stale socket %s: %w", path, err)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return nil, fmt.Errorf("stat socket %s: %w", path, err)
+	}
+
+	l, err := net.Listen("unix", path)
+	if err != nil {
+		return nil, err
+	}
+	if err := os.Chmod(path, unixSocketMode()); err != nil {
+		l.Close()
+		return nil, fmt.Errorf("chmod socket %s: %w", path, err)
+	}
+	return l, nil
+}
 
 func API(ctx context.Context, l string, defaultInterval, timeout time.Duration, e *node.Node, bwc metrics.Reporter, debugMode bool) error {
 
@@ -75,8 +152,10 @@ func API(ctx context.Context, l string, defaultInterval, timeout time.Duration, 
 
 	ec := echo.New()
 
-	if strings.HasPrefix(l, "unix://") {
-		unixListener, err := net.Listen("unix", strings.ReplaceAll(l, "unix://", ""))
+	var unixSocketPath string
+	if strings.HasPrefix(l, UnixSocketScheme) {
+		unixSocketPath = strings.TrimPrefix(l, UnixSocketScheme)
+		unixListener, err := listenUnix(unixSocketPath)
 		if err != nil {
 			return err
 		}
@@ -337,16 +416,29 @@ func API(ctx context.Context, l string, defaultInterval, timeout time.Duration, 
 
 	ec.HideBanner = true
 
-	if err := ec.Start(l); err != nil && err != http.ErrServerClosed {
-		return err
-	}
-
+	// Tie the server's lifetime to ctx so callers can stop us from
+	// the outside. Registering the watcher BEFORE ec.Start avoids
+	// the dead-goroutine pattern where Shutdown was scheduled after
+	// the blocking call.
 	go func() {
 		<-ctx.Done()
 		ct, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		ec.Shutdown(ct)
-		cancel()
+		defer cancel()
+		_ = ec.Shutdown(ct)
 	}()
 
+	startErr := ec.Start(l)
+
+	// Always remove the socket on exit — a leftover file would block
+	// the next startup with "address already in use" until listenUnix
+	// reaps it, and leaving sockets around after the process is gone
+	// is generally a footgun for orchestration tooling.
+	if unixSocketPath != "" {
+		_ = os.Remove(unixSocketPath)
+	}
+
+	if startErr != nil && !errors.Is(startErr, http.ErrServerClosed) {
+		return startErr
+	}
 	return nil
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
 	"path/filepath"
 	"time"
@@ -75,6 +76,75 @@ var _ = Describe("API", func() {
 				d.Unmarshal(&s)
 				return s
 			}, 10*time.Second, 1*time.Second).Should(Equal("bar"))
+		})
+
+		It("applies hardened permissions to the socket file", func() {
+			d, _ := ioutil.TempDir("", "xxx-perm")
+			defer os.RemoveAll(d)
+			socket := filepath.Join(d, "socket")
+
+			token := node.GenerateNewConnectionData().Base64()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			l := node.Logger(logger.New(log.LevelFatal))
+			e, _ := node.New(node.FromBase64(true, true, token, nil, nil), node.WithStore(&blockchain.MemoryStore{}), l)
+			e.Start(ctx)
+
+			go func() {
+				_ = API(ctx, "unix://"+socket, 10*time.Second, 20*time.Second, e, nil, false)
+			}()
+
+			// Wait for the socket to actually appear before asserting on perms.
+			Eventually(func() error {
+				_, err := os.Stat(socket)
+				return err
+			}, 5*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+
+			fi, err := os.Stat(socket)
+			Expect(err).ToNot(HaveOccurred())
+			// We must NOT be world-writable; that's the entire point of moving
+			// off 127.0.0.1. Owner+group RW (0660) is the documented default.
+			Expect(fi.Mode().Perm() & 0o002).To(Equal(os.FileMode(0)),
+				"socket must not be world-writable, got mode %o", fi.Mode().Perm())
+			Expect(fi.Mode()&os.ModeSocket).ToNot(Equal(os.FileMode(0)),
+				"file must be a unix socket")
+		})
+
+		It("reaps a stale socket file from a previous run", func() {
+			d, _ := ioutil.TempDir("", "xxx-stale")
+			defer os.RemoveAll(d)
+			socket := filepath.Join(d, "socket")
+
+			// Simulate a crashed previous instance by binding+closing
+			// a socket at the target path. net.Listen would otherwise
+			// fail with "address already in use" on the second bind.
+			pre, err := net.Listen("unix", socket)
+			Expect(err).ToNot(HaveOccurred())
+			pre.Close() // leaves the file on disk
+
+			token := node.GenerateNewConnectionData().Base64()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			l := node.Logger(logger.New(log.LevelFatal))
+			e, _ := node.New(node.FromBase64(true, true, token, nil, nil), node.WithStore(&blockchain.MemoryStore{}), l)
+			e.Start(ctx)
+
+			started := make(chan error, 1)
+			go func() {
+				started <- API(ctx, "unix://"+socket, 10*time.Second, 20*time.Second, e, nil, false)
+			}()
+
+			c := client.NewClient(client.WithHost("unix://" + socket))
+			// Successful Put proves the listener is up on the reused
+			// path; checking err==nil is the cleanest signal because
+			// GetBuckets returns an empty slice (not an error) when
+			// the ledger has no entries yet.
+			Eventually(func() error {
+				return c.Put("stale", "key", "v")
+			}, 5*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred())
+			_ = started
 		})
 	})
 })

--- a/api/client/client.go
+++ b/api/client/client.go
@@ -36,17 +36,30 @@ type (
 	}
 )
 
+// UnixSocketScheme is the URI prefix that selects a unix domain
+// socket connection. Mirrors api.UnixSocketScheme so callers can
+// reference it without importing the api package.
+const UnixSocketScheme = "unix://"
+
 func WithHost(host string) func(c *Client) error {
 	return func(c *Client) error {
 		c.host = host
-		if strings.HasPrefix(host, "unix://") {
-			socket := strings.ReplaceAll(host, "unix://", "")
+		if strings.HasPrefix(host, UnixSocketScheme) {
+			socket := strings.TrimPrefix(host, UnixSocketScheme)
+			// HTTP needs a valid-looking host in the URL; "unix" is a
+			// synthetic placeholder — the actual dial target is the
+			// socket path picked up by DialContext.
 			c.host = "http://unix"
-			c.httpClient = &http.Client{
-				Transport: &http.Transport{
-					DialContext: func(_ context.Context, _, _ string) (net.Conn, error) {
-						return net.Dial("unix", socket)
-					},
+			// Swap only the transport, preserving any timeout already
+			// set on the http.Client by WithTimeout / WithHTTPClient
+			// so ordering of options does not silently drop config.
+			if c.httpClient == nil {
+				c.httpClient = &http.Client{}
+			}
+			c.httpClient.Transport = &http.Transport{
+				DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+					var d net.Dialer
+					return d.DialContext(ctx, "unix", socket)
 				},
 			}
 		}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -70,7 +70,7 @@ func MainFlags() []cli.Flag {
 		&cli.StringFlag{
 			Name:    "api-listen",
 			Value:   "127.0.0.1:8080",
-			Usage:   "API listening port",
+			Usage:   "API listen address. Accepts a TCP host:port or a unix socket path with the 'unix://' prefix (e.g. unix:///run/edgevpn.sock). Socket mode defaults to 0660 and can be overridden via APILISTENUNIXMODE.",
 			EnvVars: []string{"APILISTEN"},
 		},
 		&cli.BoolFlag{


### PR DESCRIPTION
The local API already accepted a `unix://` prefix, but the listener created a socket with the kernel-default mode (often world-writable) and never cleaned up the file on shutdown — defeating the whole purpose of moving off 127.0.0.1.

This change:

- Adds listenUnix() which removes a stale socket left behind by a crashed run (only when it's actually a socket — refuses to touch regular files), binds, and chmods the socket before the first Accept. Default mode is 0660; override with APILISTENUNIXMODE (octal, e.g. "0600"). Unparseable values fall back to 0660 so a typo cannot accidentally widen perms.
- Moves the ctx.Done() watcher to fire BEFORE ec.Start blocks, and removes the socket file after Shutdown — orchestrators no longer need a "rm -f" pre-step on restart.
- Client: WithHost("unix://...") now only swaps the http.Transport instead of replacing the entire http.Client, so a prior WithTimeout / WithHTTPClient is preserved regardless of option ordering.
- Tests: added coverage for socket permissions (not world-writable) and stale-socket reuse.
- CLI: --api-listen / APILISTEN help text documents the unix:// prefix and the mode env var.