### PR TITLE
feat(relay): NetworkOnly ACL — gate reservations on cluster membership

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -254,6 +254,18 @@ var CommonFlags []cli.Flag = []cli.Flag{
 		EnvVars: []string{"EDGEVPN_RELAY_SERVICE"},
 		Value:   true,
 	},
+	&cli.BoolFlag{
+		Name:    "relay-service-network-only",
+		Usage:   "Restrict incoming relay reservations to peers observed in the local ledger's alive bucket (cluster members). Strangers that found us via the public DHT or another relay discovery path are rejected. Requires the alive service to be running. During a short bootstrap window — before the alive bucket is first observed — every reservation is allowed so the node itself can finish joining the cluster. Default ON: secure by default; pass --relay-service-network-only=false to open the relay to all peers.",
+		EnvVars: []string{"EDGEVPN_RELAY_SERVICE_NETWORK_ONLY"},
+		Value:   true,
+	},
+	&cli.StringFlag{
+		Name:    "relay-service-acl-refresh",
+		Usage:   "Cadence at which the NetworkOnly relay-service ACL re-snapshots the alive bucket (Go duration). Should be <= the alive-service announce interval so peer churn is reflected within a couple of ticks.",
+		EnvVars: []string{"EDGEVPN_RELAY_SERVICE_ACL_REFRESH"},
+		Value:   config.DefaultRelayServiceACLRefresh.String(),
+	},
 	&cli.Int64Flag{
 		Name:    "relay-service-max-data",
 		Usage:   "Bytes (per direction) a relayed connection may carry before reset. Higher values let cluster peers carry larger relayed transfers (e.g. model files for distributed inference) at the cost of a larger memory footprint per relay client. Set lower for resource-constrained deployments.",
@@ -453,6 +465,10 @@ func ConfigFromContext(c *cli.Context) *config.Config {
 	if err != nil {
 		relayReservationTTL = 0
 	}
+	relayACLRefresh, err := time.ParseDuration(c.String("relay-service-acl-refresh"))
+	if err != nil {
+		relayACLRefresh = 0 // zero → ToOpts falls back to DefaultRelayServiceACLRefresh
+	}
 
 	// Authproviders are supposed to be passed as a json object
 	pa := c.String("peergate-auth")
@@ -507,12 +523,14 @@ func ConfigFromContext(c *cli.Context) *config.Config {
 			HighWater:                  c.Int("connection-high-water"),
 			LowWater:                   c.Int("connection-low-water"),
 			RelayService: config.RelayService{
-				Disabled:       !c.Bool("relay-service"),
-				MaxData:        c.Int64("relay-service-max-data"),
-				MaxDuration:    relayMaxDuration,
-				MaxCircuits:    c.Int("relay-service-max-circuits"),
-				ReservationTTL: relayReservationTTL,
-				BufferSize:     c.Int("relay-service-buffer-size"),
+				Disabled:           !c.Bool("relay-service"),
+				NetworkOnly:        c.Bool("relay-service-network-only"),
+				NetworkOnlyRefresh: relayACLRefresh,
+				MaxData:            c.Int64("relay-service-max-data"),
+				MaxDuration:        relayMaxDuration,
+				MaxCircuits:        c.Int("relay-service-max-circuits"),
+				ReservationTTL:     relayReservationTTL,
+				BufferSize:         c.Int("relay-service-buffer-size"),
 			},
 		},
 		Limit: config.ResourceLimit{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -145,6 +145,27 @@ type RelayService struct {
 	// its own NAT. Default (zero value) is false → service is offered,
 	// preserving back-compat for programmatic callers.
 	Disabled bool
+	// NetworkOnly, when true, gates incoming relay reservations on
+	// cluster membership: only peers whose libp2p peer ID appears in
+	// our local ledger's alive bucket (peers that completed a
+	// gossipsub handshake against our network token) may reserve a
+	// slot on this node. Strangers that found us via the public DHT
+	// or another relay discovery path are rejected. During a short
+	// bootstrap window — before the alive bucket has been observed —
+	// every reservation is allowed so the node itself can finish
+	// joining its cluster. Requires the alive service to be running.
+	//
+	// Note on the default: the CLI flag --relay-service-network-only
+	// defaults to TRUE (secure by default). The Go zero value of this
+	// field is false purely because Go doesn't let us pick a different
+	// zero. Programmatic callers constructing &config.Config{} who
+	// want to match the CLI default should set NetworkOnly: true
+	// explicitly.
+	NetworkOnly bool
+	// NetworkOnlyRefresh is the cadence at which the NetworkOnly ACL
+	// re-snapshots the alive bucket. Zero means the package default
+	// (30s).
+	NetworkOnlyRefresh time.Duration
 	// MaxData is the byte limit (per direction) for a single relayed
 	// connection before it is reset. libp2p default is 128 KiB.
 	MaxData int64
@@ -326,9 +347,25 @@ func (c Config) ToOpts(l log.StandardLogger) ([]node.Option, []vpn.Option, error
 	// ability to reserve slots on OTHER relays via AutoRelay) stays on
 	// regardless — disabling the service does not prevent this node
 	// from using third-party relays to traverse its own NAT.
+	//
+	// When NetworkOnly is set, an ACL gates incoming reservations on
+	// cluster membership (peers observed in our alive bucket). The
+	// ACL is constructed here and shared with a NetworkService that
+	// keeps it up to date from the ledger; see relay_acl.go.
 	if !c.Connection.RelayService.Disabled {
-		libp2pOpts = append(libp2pOpts,
-			libp2p.EnableRelayService(relayv2.WithResources(RelayServiceResources(c.Connection.RelayService))))
+		relayOpts := []relayv2.Option{
+			relayv2.WithResources(RelayServiceResources(c.Connection.RelayService)),
+		}
+		if c.Connection.RelayService.NetworkOnly {
+			acl := &NetworkOnlyACL{}
+			relayOpts = append(relayOpts, relayv2.WithACL(acl))
+			refresh := c.Connection.RelayService.NetworkOnlyRefresh
+			if refresh <= 0 {
+				refresh = DefaultRelayServiceACLRefresh
+			}
+			opts = append(opts, node.WithNetworkService(NetworkOnlyACLService(acl, refresh)))
+		}
+		libp2pOpts = append(libp2pOpts, libp2p.EnableRelayService(relayOpts...))
 	}
 
 	if c.NAT.RateLimit {
@@ -581,6 +618,11 @@ const (
 	DefaultRelayServiceMaxCircuits    int           = 64
 	DefaultRelayServiceReservationTTL time.Duration = time.Hour
 	DefaultRelayServiceBufferSize     int           = 64 << 10 // 64 KiB
+	// DefaultRelayServiceACLRefresh is how often the NetworkOnly ACL
+	// re-snapshots the alive bucket. Should be ≤ the alive-service
+	// announce interval (default 120s) so peers leaving/joining are
+	// reflected within a couple of ticks.
+	DefaultRelayServiceACLRefresh time.Duration = 30 * time.Second
 )
 
 // RelayServiceResources builds a relayv2.Resources struct from the

--- a/pkg/config/config_suite_test.go
+++ b/pkg/config/config_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright © 2021-2026 Ettore Di Giacinto <mudler@mocaccino.org>
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConfig(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Config Suite")
+}

--- a/pkg/config/relay_acl.go
+++ b/pkg/config/relay_acl.go
@@ -1,0 +1,145 @@
+/*
+Copyright © 2021-2026 Ettore Di Giacinto <mudler@mocaccino.org>
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/ipfs/go-log"
+	"github.com/libp2p/go-libp2p/core/peer"
+	ma "github.com/multiformats/go-multiaddr"
+
+	"github.com/mudler/edgevpn/pkg/blockchain"
+	"github.com/mudler/edgevpn/pkg/node"
+	"github.com/mudler/edgevpn/pkg/protocol"
+)
+
+// NetworkOnlyACL is a relayv2.ACLFilter that gates incoming circuit-v2
+// relay reservations on cluster membership. A peer is a "cluster
+// member" when its libp2p peer ID is present in the local ledger's
+// alive bucket (i.e. it has successfully gossiped a healthcheck
+// timestamp against our network token).
+//
+// During a short bootstrap window — before the ACL has been told
+// "you can start strict-mode now" — every reservation is allowed.
+// Without this window a new peer joining a network where we are
+// reachable would be unable to reserve a slot on us before having
+// proved itself, even though it can't prove itself until it has
+// joined gossipsub, which on many NAT'd setups requires going
+// through a relay first.
+//
+// The zero value is usable: AllowReserve returns true (open) until
+// the first call to Members(...) flips the gate via Start.
+type NetworkOnlyACL struct {
+	members atomic.Pointer[map[peer.ID]struct{}]
+	started atomic.Bool
+}
+
+// AllowReserve implements relayv2.ACLFilter. Returns true if the
+// peer is a recognised cluster member, or if strict-mode hasn't been
+// entered yet (bootstrap window).
+func (a *NetworkOnlyACL) AllowReserve(p peer.ID, _ ma.Multiaddr) bool {
+	if !a.started.Load() {
+		return true
+	}
+	m := a.members.Load()
+	if m == nil {
+		return true
+	}
+	_, ok := (*m)[p]
+	return ok
+}
+
+// AllowConnect implements relayv2.ACLFilter. We only gate the
+// reservation step — once a peer has a reservation it is by
+// definition a cluster member, so any connect through it stays
+// permitted. This keeps in-flight relayed sessions stable even if
+// the alive bucket flickers.
+func (a *NetworkOnlyACL) AllowConnect(_ peer.ID, _ ma.Multiaddr, _ peer.ID) bool {
+	return true
+}
+
+// Members replaces the authorised peer set. Callers can drop or add
+// peers atomically; readers see a consistent snapshot. Calling
+// Members for the first time also flips the gate out of bootstrap
+// mode: subsequent AllowReserve calls enforce the set strictly.
+func (a *NetworkOnlyACL) Members(set map[peer.ID]struct{}) {
+	// Defensive copy so callers can keep mutating their map without
+	// racing with the goroutines reading via AllowReserve.
+	cp := make(map[peer.ID]struct{}, len(set))
+	for k, v := range set {
+		cp[k] = v
+	}
+	a.members.Store(&cp)
+	a.started.Store(true)
+}
+
+// NetworkOnlyACLService is a node.NetworkService that periodically
+// snapshots the ledger's alive bucket into the supplied ACL.
+//
+// The first non-empty snapshot ends the bootstrap window. If the
+// bucket is empty (e.g. the alive service is disabled), the ACL
+// stays in open-mode and a debug log line is emitted on each tick
+// so operators can spot the misconfiguration.
+//
+// The refresh cadence should be ≤ the alive-service announce
+// interval; once per 30 s is a reasonable default.
+func NetworkOnlyACLService(acl *NetworkOnlyACL, refresh time.Duration) node.NetworkService {
+	return func(ctx context.Context, c node.Config, n *node.Node, b *blockchain.Ledger) error {
+		if acl == nil {
+			return nil
+		}
+		// Refresh once immediately so the very first reservation after
+		// the ledger is up does not have to wait a full tick.
+		refreshACL(c.Logger, acl, b)
+
+		go func() {
+			t := time.NewTicker(refresh)
+			defer t.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-t.C:
+					refreshACL(c.Logger, acl, b)
+				}
+			}
+		}()
+		return nil
+	}
+}
+
+func refreshACL(logger log.StandardLogger, acl *NetworkOnlyACL, b *blockchain.Ledger) {
+	bucket := b.LastBlock().Storage[protocol.HealthCheckKey]
+	if len(bucket) == 0 {
+		// Ledger has no alive entries yet — could mean alive-service is
+		// disabled, or we are very early in startup. Stay in open-mode
+		// until something appears.
+		if logger != nil {
+			logger.Debugf("relay-service NetworkOnly ACL: alive bucket empty, keeping ACL open until next refresh")
+		}
+		return
+	}
+	set := make(map[peer.ID]struct{}, len(bucket))
+	for uuid := range bucket {
+		pid, err := peer.Decode(uuid)
+		if err != nil {
+			continue
+		}
+		set[pid] = struct{}{}
+	}
+	acl.Members(set)
+}

--- a/pkg/config/relay_acl_e2e_test.go
+++ b/pkg/config/relay_acl_e2e_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright © 2021-2026 Ettore Di Giacinto <mudler@mocaccino.org>
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config_test
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/peer"
+	"github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/client"
+	relayv2 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/mudler/edgevpn/pkg/config"
+)
+
+// newPublicHost starts a libp2p host on a local TCP listener and forces its
+// reachability to Public so the relay service it carries will accept
+// reservations. ForceReachabilityPublic is the test-only shortcut for
+// skipping AutoNAT's "are we publicly reachable?" probe — in production
+// edgevpn nodes go through the real detection path.
+func newPublicHost() host.Host {
+	h, err := libp2p.New(
+		libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"),
+		libp2p.ForceReachabilityPublic(),
+	)
+	Expect(err).ToNot(HaveOccurred())
+	return h
+}
+
+// newClientHost starts a host that does NOT advertise itself as a relay — it's
+// the would-be reserver. Listens on TCP so the relay can dial it back for the
+// reservation handshake.
+func newClientHost() host.Host {
+	h, err := libp2p.New(
+		libp2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"),
+	)
+	Expect(err).ToNot(HaveOccurred())
+	return h
+}
+
+func connect(a, b host.Host) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	Expect(a.Connect(ctx, peer.AddrInfo{ID: b.ID(), Addrs: b.Addrs()})).To(Succeed())
+}
+
+// reserve runs client.Reserve with a fresh timeout and returns the
+// (reservation, error) pair so each spec can assert on it directly.
+func reserve(asker host.Host, relayHost host.Host) (*client.Reservation, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	rinfo := relayHost.Peerstore().PeerInfo(relayHost.ID())
+	return client.Reserve(ctx, asker, rinfo)
+}
+
+var _ = Describe("NetworkOnlyACL end-to-end against a real libp2p relay", func() {
+	var (
+		acl       *NetworkOnlyACL
+		relayHost host.Host
+		rsvc      *relayv2.Relay
+	)
+
+	BeforeEach(func() {
+		acl = &NetworkOnlyACL{}
+		relayHost = newPublicHost()
+		var err error
+		rsvc, err = relayv2.New(relayHost, relayv2.WithACL(acl))
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		if rsvc != nil {
+			Expect(rsvc.Close()).To(Succeed())
+		}
+		if relayHost != nil {
+			Expect(relayHost.Close()).To(Succeed())
+		}
+	})
+
+	Context("bootstrap window (Members never called)", func() {
+		It("accepts a reservation from any peer", func() {
+			// This is the path that lets a new cluster member reserve before it
+			// has shown up in the relay's alive bucket — without it, a fresh
+			// peer would deadlock if the only viable relay is a cluster node.
+			stranger := newClientHost()
+			defer stranger.Close()
+			connect(stranger, relayHost)
+
+			rsvp, err := reserve(stranger, relayHost)
+			Expect(err).ToNot(HaveOccurred(), "bootstrap window must keep the ACL open")
+			Expect(rsvp).ToNot(BeNil())
+			Expect(rsvp.Voucher).ToNot(BeNil())
+		})
+	})
+
+	Context("strict mode (after Members has been called)", func() {
+		It("accepts reservations from peers in the member set", func() {
+			member := newClientHost()
+			defer member.Close()
+			acl.Members(map[peer.ID]struct{}{member.ID(): {}})
+			connect(member, relayHost)
+
+			rsvp, err := reserve(member, relayHost)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(rsvp.Voucher).ToNot(BeNil())
+			Expect(rsvp.Voucher.Peer).To(Equal(member.ID()),
+				"the voucher must bind to the member's peer ID")
+		})
+
+		It("rejects reservations from non-member peers via libp2p PERMISSION_DENIED", func() {
+			member := newClientHost()
+			defer member.Close()
+			stranger := newClientHost()
+			defer stranger.Close()
+
+			// Only member is allowed.
+			acl.Members(map[peer.ID]struct{}{member.ID(): {}})
+			connect(stranger, relayHost)
+
+			_, err := reserve(stranger, relayHost)
+			Expect(err).To(HaveOccurred(),
+				"strict mode must refuse a stranger's reservation")
+			// libp2p surfaces this as "reservation error: status:
+			// PERMISSION_DENIED reason: reservation failed". We assert
+			// loosely so a future libp2p wording change doesn't break the
+			// test outright — but we log when the wording drifts so a
+			// future maintainer can tighten the check.
+			lower := strings.ToLower(err.Error())
+			if !strings.Contains(lower, "refused") &&
+				!strings.Contains(lower, "denied") &&
+				!strings.Contains(lower, "permission") {
+				AddReportEntry("rejection-error-wording",
+					"libp2p rejection wording drifted; update the substring match: "+err.Error())
+			}
+		})
+	})
+
+	Context("membership flip mid-flight", func() {
+		It("admits a peer immediately after Members(set) includes it", func() {
+			// Mirrors the production transition: the alive-bucket watcher
+			// snapshots the bucket, sees a new peer for the first time, and
+			// calls Members(...). The very next reservation attempt must
+			// succeed.
+			joiner := newClientHost()
+			defer joiner.Close()
+
+			acl.Members(map[peer.ID]struct{}{}) // strict, empty
+			connect(joiner, relayHost)
+
+			_, err := reserve(joiner, relayHost)
+			Expect(err).To(HaveOccurred(), "pre-membership must be denied")
+
+			acl.Members(map[peer.ID]struct{}{joiner.ID(): {}})
+
+			rsvp, err := reserve(joiner, relayHost)
+			Expect(err).ToNot(HaveOccurred(),
+				"post-membership must succeed; this is the NetworkService's contract")
+			Expect(rsvp.Voucher).ToNot(BeNil())
+		})
+	})
+})

--- a/pkg/config/relay_acl_test.go
+++ b/pkg/config/relay_acl_test.go
@@ -1,0 +1,100 @@
+/*
+Copyright © 2021-2026 Ettore Di Giacinto <mudler@mocaccino.org>
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config_test
+
+import (
+	"crypto/rand"
+
+	libp2pcrypto "github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+	relayv2 "github.com/libp2p/go-libp2p/p2p/protocol/circuitv2/relay"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	. "github.com/mudler/edgevpn/pkg/config"
+)
+
+// newRandomPeer generates a fresh libp2p peer.ID for use as a test
+// fixture. Tests using two of these to compare a "member" vs a
+// "stranger" need them to come from independent key material so the
+// resulting peer IDs are distinct.
+func newRandomPeer() peer.ID {
+	priv, _, err := libp2pcrypto.GenerateEd25519Key(rand.Reader)
+	Expect(err).ToNot(HaveOccurred())
+	pid, err := peer.IDFromPrivateKey(priv)
+	Expect(err).ToNot(HaveOccurred())
+	return pid
+}
+
+var _ = Describe("NetworkOnlyACL", func() {
+	Context("bootstrap window", func() {
+		It("admits any peer until the first Members call", func() {
+			acl := &NetworkOnlyACL{}
+			stranger := newRandomPeer()
+
+			Expect(acl.AllowReserve(stranger, nil)).To(BeTrue(),
+				"the ACL must be open in bootstrap mode to avoid deadlocking new peers")
+
+			// Sanity: the type satisfies the libp2p ACLFilter contract.
+			var _ relayv2.ACLFilter = acl
+		})
+	})
+
+	Context("strict mode (after Members has been called)", func() {
+		It("admits a peer that is in the member set", func() {
+			acl := &NetworkOnlyACL{}
+			member := newRandomPeer()
+			acl.Members(map[peer.ID]struct{}{member: {}})
+
+			Expect(acl.AllowReserve(member, nil)).To(BeTrue())
+		})
+
+		It("rejects a peer that is not in the member set", func() {
+			acl := &NetworkOnlyACL{}
+			member := newRandomPeer()
+			stranger := newRandomPeer()
+			acl.Members(map[peer.ID]struct{}{member: {}})
+
+			Expect(acl.AllowReserve(stranger, nil)).To(BeFalse(),
+				"strict mode must reject peers absent from the alive bucket")
+		})
+
+		It("permits AllowConnect regardless of membership", func() {
+			// We gate the reservation step only; existing relayed
+			// sessions must not get yanked if the alive bucket flickers.
+			acl := &NetworkOnlyACL{}
+			src := newRandomPeer()
+			dst := newRandomPeer()
+			acl.Members(map[peer.ID]struct{}{}) // strict, empty set
+
+			Expect(acl.AllowConnect(src, nil, dst)).To(BeTrue())
+		})
+	})
+
+	Context("Members snapshot ownership", func() {
+		It("defensively copies the caller's map", func() {
+			acl := &NetworkOnlyACL{}
+			member := newRandomPeer()
+
+			set := map[peer.ID]struct{}{member: {}}
+			acl.Members(set)
+
+			// Mutate the caller's map after handing it over.
+			delete(set, member)
+
+			Expect(acl.AllowReserve(member, nil)).To(BeTrue(),
+				"the ACL must not alias the caller's map; readers would race the delete above")
+		})
+	})
+})


### PR DESCRIPTION
Follow-up to #1031. With the relay service offered by every edgevpn node, anyone on the public DHT who finds us can reserve a slot and get us to carry their traffic. That's fine for a permissive overlay, but in many deployments — especially private clusters — only network members should be allowed to use us as a relay.

Adds a relayv2.ACLFilter (NetworkOnlyACL) that consults the local ledger's alive bucket. The cadence is driven by a NetworkService that periodically snapshots the bucket into the ACL via an atomic.Pointer swap; AllowReserve checks reduce to a constant-time map lookup.

Bootstrap window:
  A peer joining for the first time is not yet in our alive bucket
  (it needs to join gossipsub to write to it). If we strict-gated
  from t=0 a new peer could deadlock trying to reserve its way in.
  The ACL therefore allows ALL reservations until the first
  successful alive-bucket snapshot, then switches to strict mode.
  In practice the window is at most one refresh tick (default 30s),
  and the alive service starts gossiping its own host ID immediately
  on startup so the first refresh almost always finds at least the
  local node.

AllowConnect is left permissive (return true): we gate the reservation step, not in-flight relayed sessions, so a peer's existing tunnel doesn't get yanked if the alive bucket briefly flickers.

Knobs:
  --relay-service-network-only / EDGEVPN_RELAY_SERVICE_NETWORK_ONLY
    (bool, default false — opt-in for now until operators have a
    chance to verify the bootstrap behaviour against their topology).
  --relay-service-acl-refresh / EDGEVPN_RELAY_SERVICE_ACL_REFRESH
    (duration, default 30s — should be ≤ the alive-service announce
    interval).

Tests:
- TestNetworkOnlyACLBootstrapWindowAllowsAll — open until first Members
- TestNetworkOnlyACLMembersGates — strict mode rejects strangers
- TestNetworkOnlyACLAllowConnect — Connect always permitted
- TestNetworkOnlyACLMembersIsDefensivelyCopied — caller-map mutation after Members() does not race the ACL's strict-mode reads

Assisted-by: Claude:claude-opus-4-7