### PR TITLE
feat(blockchain): authenticated, per-owner ledger entries (experimental)

### DIFF
--- a/cmd/util.go
+++ b/cmd/util.go
@@ -371,9 +371,9 @@ var CommonFlags []cli.Flag = []cli.Flag{
 	},
 	&cli.StringFlag{
 		Name:    "ownership",
-		Usage:   "Ledger ownership enforcement: off, observe (sign + log violations) or enforce (sign + reject). (Experimental)",
+		Usage:   "Ledger ownership enforcement: enforce (sign + reject unauthorized writes, default), observe (sign + log violations) or off (legacy, opt-out). All nodes on a network must run the same mode/wire format, so flip the whole network together.",
 		EnvVars: []string{"EDGEVPNOWNERSHIP"},
-		Value:   "off",
+		Value:   "enforce",
 	},
 	&cli.IntFlag{
 		Name:    "ownership-ttl",

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -582,31 +582,51 @@ func cliToOpts(c *cli.Context) ([]node.Option, []vpn.Option, *logger.Logger) {
 		}
 	}
 
-	// Check if we have any privkey identity cached already
-	if c.Bool("privkey-cache") {
-		keyFile := filepath.Join(c.String("privkey-cache-dir"), "privkey")
-		dat, err := os.ReadFile(keyFile)
-		if err == nil && len(dat) > 0 {
-			llger.Info("Reading key from", keyFile)
+	// Persist the libp2p identity when explicitly requested, or implicitly when
+	// ledger ownership enforcement is on. Ownership binds entries to the peer ID,
+	// so an ephemeral identity would orphan a node's entries (reaped after the
+	// liveness TTL) and force a cross-owner reclaim on every restart; a stable
+	// identity makes restarts same-owner.
+	ownMode := strings.ToLower(nc.Ownership.Mode)
+	ownershipEnabled := ownMode == "enforce" || ownMode == "on" ||
+		ownMode == "observe" || ownMode == "log" || ownMode == "log-only"
 
+	if c.Bool("privkey-cache") || ownershipEnabled {
+		keyFile := filepath.Join(c.String("privkey-cache-dir"), "privkey")
+		dat, rerr := os.ReadFile(keyFile)
+		if rerr == nil && len(dat) > 0 {
+			llger.Info("Reading key from", keyFile)
 			nc.Privkey = dat
 		} else {
-			// generate, write
 			llger.Info("Generating private key and saving it locally for later use in", keyFile)
 
-			privkey, err := node.GenPrivKey(0)
-			checkErr(err)
-
-			r, err := crypto.MarshalPrivateKey(privkey)
-			checkErr(err)
-
-			err = os.MkdirAll(c.String("privkey-cache-dir"), 0600)
-			checkErr(err)
-
-			err = os.WriteFile(keyFile, r, 0600)
-			checkErr(err)
-
+			privkey, gerr := node.GenPrivKey(0)
+			if gerr != nil {
+				llger.Fatal(gerr.Error())
+			}
+			r, merr := crypto.MarshalPrivateKey(privkey)
+			if merr != nil {
+				llger.Fatal(merr.Error())
+			}
+			// Use the freshly generated key for this run regardless of whether it
+			// can be persisted.
 			nc.Privkey = r
+
+			perr := os.MkdirAll(c.String("privkey-cache-dir"), 0700)
+			if perr == nil {
+				perr = os.WriteFile(keyFile, r, 0600)
+			}
+			switch {
+			case perr == nil:
+				llger.Info("Saved private key in", keyFile)
+			case c.Bool("privkey-cache"):
+				// Explicitly requested: keep the fail-fast behaviour.
+				llger.Fatal(perr.Error())
+			default:
+				// Auto-enabled by ownership: don't block startup, but warn that
+				// the identity will change on restart.
+				llger.Warnf("ownership enforcement is on but the identity could not be persisted to %s (%v); it will change on restart, orphaning this node's ledger entries until the liveness TTL expires. Set --privkey-cache-dir to a writable path to avoid this.", keyFile, perr)
+			}
 		}
 	}
 

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -582,16 +582,14 @@ func cliToOpts(c *cli.Context) ([]node.Option, []vpn.Option, *logger.Logger) {
 		}
 	}
 
-	// Persist the libp2p identity when explicitly requested, or implicitly when
-	// ledger ownership enforcement is on. Ownership binds entries to the peer ID,
-	// so an ephemeral identity would orphan a node's entries (reaped after the
-	// liveness TTL) and force a cross-owner reclaim on every restart; a stable
-	// identity makes restarts same-owner.
-	ownMode := strings.ToLower(nc.Ownership.Mode)
-	ownershipEnabled := ownMode == "enforce" || ownMode == "on" ||
-		ownMode == "observe" || ownMode == "log" || ownMode == "log-only"
-
-	if c.Bool("privkey-cache") || ownershipEnabled {
+	// Persist the libp2p identity only when explicitly requested. We do NOT
+	// auto-enable this under ownership enforcement: the default cache dir is
+	// shared per-user ($HOME/.edgevpn), so co-located edgevpn processes (e.g.
+	// `edgevpn api` alongside `edgevpn` VPN, or file-send/-receive) would all
+	// load the SAME key and boot with the same peer ID — a broken duplicate
+	// identity on the network. Stable identity must be an explicit per-node
+	// choice via --privkey-cache (+ a distinct --privkey-cache-dir per process).
+	if c.Bool("privkey-cache") {
 		keyFile := filepath.Join(c.String("privkey-cache-dir"), "privkey")
 		dat, rerr := os.ReadFile(keyFile)
 		if rerr == nil && len(dat) > 0 {
@@ -608,26 +606,25 @@ func cliToOpts(c *cli.Context) ([]node.Option, []vpn.Option, *logger.Logger) {
 			if merr != nil {
 				llger.Fatal(merr.Error())
 			}
-			// Use the freshly generated key for this run regardless of whether it
-			// can be persisted.
+			if merr := os.MkdirAll(c.String("privkey-cache-dir"), 0700); merr != nil {
+				llger.Fatal(merr.Error())
+			}
+			if merr := os.WriteFile(keyFile, r, 0600); merr != nil {
+				llger.Fatal(merr.Error())
+			}
 			nc.Privkey = r
-
-			perr := os.MkdirAll(c.String("privkey-cache-dir"), 0700)
-			if perr == nil {
-				perr = os.WriteFile(keyFile, r, 0600)
-			}
-			switch {
-			case perr == nil:
-				llger.Info("Saved private key in", keyFile)
-			case c.Bool("privkey-cache"):
-				// Explicitly requested: keep the fail-fast behaviour.
-				llger.Fatal(perr.Error())
-			default:
-				// Auto-enabled by ownership: don't block startup, but warn that
-				// the identity will change on restart.
-				llger.Warnf("ownership enforcement is on but the identity could not be persisted to %s (%v); it will change on restart, orphaning this node's ledger entries until the liveness TTL expires. Set --privkey-cache-dir to a writable path to avoid this.", keyFile, perr)
-			}
 		}
+	}
+
+	// Under ownership enforcement an ephemeral identity is usable but churny:
+	// on every restart the node's entries are orphaned (reaped after the
+	// liveness TTL) and re-claimed under the new identity. Nudge operators of a
+	// long-lived node toward a stable identity, without forcing it.
+	ownMode := strings.ToLower(nc.Ownership.Mode)
+	ownershipEnabled := ownMode == "enforce" || ownMode == "on" ||
+		ownMode == "observe" || ownMode == "log" || ownMode == "log-only"
+	if ownershipEnabled && len(nc.Privkey) == 0 {
+		llger.Warnf("ownership enforcement is on with an ephemeral identity: this node's ledger entries will be reclaimed after the liveness TTL on each restart. Use --privkey-cache with a per-node --privkey-cache-dir for a stable identity.")
 	}
 
 	for _, pt := range c.StringSlice("static-peertable") {

--- a/cmd/util.go
+++ b/cmd/util.go
@@ -369,6 +369,18 @@ var CommonFlags []cli.Flag = []cli.Flag{
 		Usage:   "Enable peerguard. (Experimental)",
 		EnvVars: []string{"PEERGUARD"},
 	},
+	&cli.StringFlag{
+		Name:    "ownership",
+		Usage:   "Ledger ownership enforcement: off, observe (sign + log violations) or enforce (sign + reject). (Experimental)",
+		EnvVars: []string{"EDGEVPNOWNERSHIP"},
+		Value:   "off",
+	},
+	&cli.IntFlag{
+		Name:    "ownership-ttl",
+		Usage:   "Liveness window in seconds after which an inactive owner's ledger entries may be reclaimed/reaped (0 = default).",
+		EnvVars: []string{"EDGEVPNOWNERSHIPTTL"},
+		Value:   0,
+	},
 	&cli.BoolFlag{
 		Name:    "privkey-cache",
 		Usage:   "Enable privkey caching. (Experimental)",
@@ -547,6 +559,10 @@ func ConfigFromContext(c *cli.Context) *config.Config {
 			Autocleanup:   c.Bool("peergate-autoclean"),
 			SyncInterval:  time.Duration(c.Int("peergate-interval")) * time.Second,
 			AuthProviders: d,
+		},
+		Ownership: config.Ownership{
+			Mode: c.String("ownership"),
+			TTL:  time.Duration(c.Int("ownership-ttl")) * time.Second,
 		},
 	}
 }

--- a/docs/design/authenticated-ledger.md
+++ b/docs/design/authenticated-ledger.md
@@ -264,10 +264,14 @@ By default the identity is **ephemeral**: with no configured key, `GenPrivKey(0)
   via cross-owner reclaim (allowed only once the old owner expires). This works but adds churn and
   a reclaim delay of up to the TTL on every restart.
 
-For this reason the binary **auto-enables identity persistence whenever ownership is on**
-(`enforce`/`observe`): `cmd/util.go` reads/creates `<privkey-cache-dir>/privkey` even without an
-explicit `--privkey-cache`, and warns (rather than failing) if it cannot persist, so an operator
-who has not opted into stable identities still gets clean restarts under enforcement.
+For long-lived nodes a stable identity is therefore recommended under enforcement
+(`--privkey-cache`). The binary does **not** auto-enable it: the default cache dir is shared
+per-user (`$HOME/.edgevpn`), so auto-persisting would make co-located processes (e.g. `edgevpn
+api` next to the VPN, or `file-send`/`file-receive`) load the *same* key and boot with a
+duplicate peer ID. Instead, `cmd/util.go` emits a one-line warning when ownership is on with an
+ephemeral identity, pointing operators at `--privkey-cache` (with a distinct `--privkey-cache-dir`
+per process). Ephemeral identities still work — restarts just churn (orphan → reclaim after the
+liveness TTL).
 
 **Security boundary.** Token = admission (keeps outsiders out); identity = per-write integrity
 (keeps insiders from impersonating each other — a leaked token still cannot let peer A write peer

--- a/docs/design/authenticated-ledger.md
+++ b/docs/design/authenticated-ledger.md
@@ -127,8 +127,13 @@ Default registry:
 | `files`         | yes   | `PeerID` field     | Liveness        | yes         |
 | `users`         | yes   | key == peer.ID     | Liveness        | no          |
 | `healthcheck`   | yes   | key == peer.ID     | Absolute(maxTime) | no        |
-| `dns`           | *(follow-up)* | `PeerID` field | Liveness    | yes (first-claim) |
+| `dns`           | yes   | self-owned (nil OwnerOf) | Liveness  | yes (first-claim) |
 | *(unregistered)*| no    | —                  | NoExpiry        | —           |
+
+A `nil` `OwnerOf` marks a **self-owned** bucket: the value carries no owner field,
+so the first signer to claim a key owns it (first-claim), and the normal
+cross-owner/expiry rules then protect it. `dns` uses this so it needs no change to
+the `types.DNS` record shape.
 
 An unregistered bucket is the zero value: open + never expires → unchanged behaviour, which
 is what keeps the change backwards compatible for any bucket we have not opted in.
@@ -213,10 +218,9 @@ targeted, registry-driven reaping across all TTL buckets.
 
 > Implementation note: layers (2) and (3) are implemented (`Ledger.Reap`, wired into the
 > alive service's leader path), and tombstoned entries already read as absent via
-> `GetKey`/`CurrentData`. Layer (1), an explicit `IsLive(owner)` guard inlined at each
-> read site (routing/dial/resolve) for sub-scrub-interval immediacy, is a follow-up — until
-> then a dead owner's entry is skipped as soon as the reaper tombstones it (within one scrub
-> interval), and routing to an already-gone peer simply fails in the meantime.
+> `GetKey`/`CurrentData`. Layer (1) is implemented for VPN routing via
+> `Ledger.IsOwnerLive` (a no-op when ownership is off); applying the same guard at the
+> service/file dial sites is a small further addition.
 
 ## 10. Wiring
 
@@ -271,13 +275,14 @@ buckets. Strategy for a single PR:
 
 ## 15. Known limitations / follow-ups
 
-- **DNS ownership.** `types.DNS` carries no owner field, so the `dns` bucket is left
-  open (unauthenticated) in this iteration. Closing the DNS-poisoning vector under
-  enforcement requires adding an owner peer.ID to the record, having the dns service
-  stamp it, and (per the chosen policy) first-claim + lease semantics. The registry is
-  the single place to opt it in once that lands.
-- **Reader-side lazy `IsLive` guards.** Implemented reaping + tombstone hiding; the
-  inlined per-read `IsLive(owner)` guard (sub-scrub-interval immediacy) is a follow-up.
+- **DNS ownership.** Implemented as a self-owned bucket (first-claim + lease), so
+  hijacking an *existing* DNS name owned by a live peer is blocked and dead owners'
+  records are reaped. Still open as further hardening: constraining *which* names a
+  peer may register (e.g. rejecting `.*` catch-alls) and binding a record's targets to
+  the owner's own address.
+- **Reader-side `IsLive` guards.** Implemented for VPN routing (`Ledger.IsOwnerLive`),
+  in addition to reaping + tombstone hiding. The same guard at the service/file dial
+  sites is a small further addition.
 - **Wire format.** Observe/enforce modes change the on-wire entry encoding to the signed
   object form; a network running observe/enforce must have all nodes on this version.
   The default (`off`) keeps the exact legacy bare-value encoding, so mixed old/new nodes

--- a/docs/design/authenticated-ledger.md
+++ b/docs/design/authenticated-ledger.md
@@ -1,0 +1,287 @@
+# Authenticated, per-owner ledger entries
+
+Status: **proposed** · Target: single PR · Default behaviour: **unchanged** until `--enforce-ownership` is set.
+
+## 1. Problem
+
+EdgeVPN's only trust boundary today is *knowledge of the network token*. Every peer
+that holds the token is fully, equally and permanently trusted. The shared ledger
+(`pkg/blockchain`) is the control plane for the whole network — it stores IP→peer
+mappings, services, files and DNS records — yet:
+
+- Blocks are **unsigned**. `Block.Checksum()` hashes only `Index|Timestamp|Storage|PrevHash`;
+  there is no notion of *who* authored an entry.
+- `Ledger.Update` adopts any incoming block whose `Index` is higher (hash breaks ties)
+  and **whole-replaces** local state. There is no per-key authorisation.
+
+Consequences (see the security audit): any in-network peer can overwrite *any* key —
+hijack another node's IP (MITM), poison DNS (`.*` record), hijack services/files, or
+take over global state. Every "ownership" check in `pkg/vpn`/`pkg/services` reads its
+authority from the same ledger the attacker rewrites, so those checks are self-referential.
+
+A second, operational problem: entries owned by a node that has gone away linger
+forever (the ledger is "pestered by old entries"), because deletion is best-effort and
+not tied to liveness.
+
+## 2. Goals
+
+1. A write to a peer-owned key is only accepted if it is **signed by the owning peer**.
+2. An entry cannot be **rolled back or replayed** to an older value.
+3. Entries owned by an **inactive** node expire and are **reaped**, bounding ledger size.
+4. **Extensible**: adding a new bucket with ownership + TTL is a one-line registry entry.
+5. **Backwards compatible by default**: ships behind a flag; existing networks keep working.
+
+Non-goals: changing the libp2p transport, the seal-key/OTP scheme, or per-peer message
+encryption. This work is purely about *authorising writes to the ledger* and *bounding
+its lifetime*.
+
+## 3. Core idea
+
+The ledger already behaves as a single shared snapshot (`MemoryStore` keeps only
+`Last()`; the chain is never validated). We lean into that:
+
+> **State is a map of independently *signed*, *versioned* entries. A "block" is just the
+> transport envelope carrying a snapshot of them.** Security moves from the block (height)
+> to the entry (owner signature + monotonic version).
+
+Forging another peer's entry then requires that peer's private key. Convergence becomes
+per-entry (highest version wins, deterministic tie-break) instead of a global height race,
+which also removes the split-brain hack the current `Update` comment describes.
+
+## 4. Data model
+
+```go
+// pkg/blockchain/data.go
+type SignedData struct {
+    Value     Data   // existing JSON payload — unchanged, readers still Unmarshal this
+    Owner     string // peer.ID (base58) of the author
+    Version   uint64 // monotonic per (bucket,key); only bumps when Value changes
+    UpdatedAt int64  // unix seconds — signed; drives Absolute TTL & lease renewal
+    Deleted   bool   // signed tombstone
+    Sig       []byte // Ed25519 over canonical(bucket,key,Owner,Version,UpdatedAt,Deleted,Value)
+}
+```
+
+`Block.Storage` becomes `map[string]map[string]SignedData`. The inner `Data` type is kept,
+so every reader in `pkg/vpn`/`pkg/services` keeps calling `entry.Value.Unmarshal(&x)`.
+
+`Block.Checksum()` stays for transport integrity only; it is **no longer** the security
+boundary.
+
+### Canonical encoding
+
+Signing input is a length-prefixed concatenation of the fields (never Go `fmt`/map
+ordering) so the signed bytes are identical on every node:
+
+```
+canonical = len|bucket ‖ len|key ‖ len|owner ‖ u64|version ‖ i64|updatedAt ‖ b|deleted ‖ len|value
+```
+
+## 5. Signing & verification (`pkg/blockchain/sign.go`)
+
+- **Key = the libp2p host identity key** (Ed25519, already generated in `genHost`). No new
+  keys, no PKI.
+- **Verification needs no key distribution**: `peer.Decode(Owner).ExtractPublicKey()`
+  recovers the public key directly from the peer ID (works because EdgeVPN forces Ed25519).
+- A `Signer` is injected into the ledger:
+
+```go
+type Signer interface {
+    Sign(msg []byte) ([]byte, error)
+    ID() string // base58 peer.ID of the signer
+}
+```
+
+In tests this is a fake key; in production it is built from the host key after `genHost`.
+
+## 6. Ownership & TTL registry (`pkg/blockchain/policy.go`)
+
+The single source of truth for "what is signed and what is under TTL". Adding a feature
+bucket = adding one row. The merge engine, the reaper and the readers all consult it.
+
+```go
+type ExpiryKind int
+const (
+    NoExpiry ExpiryKind = iota // never expires (default for unregistered buckets)
+    Liveness                   // alive iff the OWNER's heartbeat is fresh
+    Absolute                   // alive iff now-UpdatedAt < TTL
+)
+
+type BucketPolicy struct {
+    Owned       bool                            // signed + owner-enforced?
+    OwnerOf     func(key string, v Data) string // who owns this entry
+    Expiry      ExpiryKind
+    TTL         time.Duration                   // only for Absolute
+    Reclaimable bool                            // may a non-owner claim after expiry?
+}
+
+type Registry map[string]BucketPolicy
+```
+
+Default registry:
+
+| Bucket          | Owned | OwnerOf            | Expiry          | Reclaimable |
+|-----------------|-------|--------------------|-----------------|-------------|
+| `machines`      | yes   | `PeerID` field     | Liveness        | yes         |
+| `services`      | yes   | `PeerID` field     | Liveness        | yes         |
+| `files`         | yes   | `PeerID` field     | Liveness        | yes         |
+| `users`         | yes   | key == peer.ID     | Liveness        | no          |
+| `healthcheck`   | yes   | key == peer.ID     | Absolute(maxTime) | no        |
+| `dns`           | *(follow-up)* | `PeerID` field | Liveness    | yes (first-claim) |
+| *(unregistered)*| no    | —                  | NoExpiry        | —           |
+
+An unregistered bucket is the zero value: open + never expires → unchanged behaviour, which
+is what keeps the change backwards compatible for any bucket we have not opted in.
+
+### Two expiry kinds
+
+- **`Liveness`** — the entry is alive iff its owner's heartbeat (`HealthCheckKey`) is fresh
+  (`owner ∈ AvailableNodes(maxTime)`). One heartbeat governs *all* of a node's entries: when
+  a node goes inactive, its IP, services, files and DNS names expire together. This is the
+  answer to "a node becoming inactive" — we never track entries individually.
+- **`Absolute(d)`** — expires `d` after the entry's own signed `UpdatedAt`, independent of
+  owner liveness (used for the heartbeat bucket itself and any future ephemeral key).
+
+Lease renewal is free: the existing `Persist`/`AnnounceUpdate` loops already re-announce
+each entry periodically; under the new model that re-sign bumps `UpdatedAt`.
+
+## 7. The merge — `Ledger.Update` rewrite
+
+`Update` stops doing height-wins-whole-replace and merges entry by entry into current state:
+
+```
+for each (bucket, key, incoming) in block.Storage:
+    pol = registry[bucket]
+    if !pol.Owned:                      accept (legacy/open bucket); continue
+    if !verifySig(bucket, key, incoming):                       drop   // forged / corrupt
+    if pol.OwnerOf(key, incoming.Value) != incoming.Owner:      drop   // e.g. Owner != Machine.PeerID
+    cur = state[bucket][key]
+    if cur exists:
+        if incoming.Owner != cur.Owner && !expired(pol, cur):   drop   // hijack attempt
+        if incoming.Version <  cur.Version:                     drop   // rollback / replay
+        if incoming.Version == cur.Version && incoming.Sig != cur.Sig:
+            keep deterministic winner (Owner, then Sig bytes)          // anti-flap
+    accept incoming
+```
+
+- **Per-key versions** make rollback/replay impossible without out-versioning the owner —
+  which only the owner can sign.
+- **Cross-owner writes are allowed iff the current owner's lease has expired.** This single
+  rule powers both *reclaim* (peer B takes a dead peer's IP) and *reaping* (the leader
+  tombstones a dead peer's entry).
+- **`--enforce-ownership` dual mode**: when **off** (default), every `drop` above is instead
+  a `WARN` log + accept (so operators can observe violations on a live network without
+  breaking it); when **on**, drops are enforced. Verification and signing always run.
+
+## 8. Write path
+
+`Add(bucket, {key: value})`:
+1. read current entry; if `Value` unchanged → keep `Version` (idempotent under the
+   `AnnounceUpdate`/`Persist` re-announce loops), else `Version = cur.Version + 1`;
+2. set `Owner = signer.ID()`, `UpdatedAt = now`, `Deleted = false`;
+3. sign canonical bytes → `Sig`; store.
+
+`Delete`/`DeleteBucket`/`AnnounceDeleteBucket*` emit **signed tombstones** (`Deleted=true`,
+`Version` bumped, empty `Value`) instead of dropping keys, so a delete propagates and an old
+value cannot be replayed over it.
+
+## 9. Reaping inactive nodes
+
+Two layers, both built on existing primitives (`HealthCheckKey`, `AvailableNodes`,
+`utils.Leader`).
+
+1. **Reader-side lazy expiry (free, immediate).** Every reader (`vpn` routing, `services`
+   dial, `dns` resolve) wraps lookups with `policy.IsLive(owner)`. The instant a node's
+   heartbeat goes stale, traffic stops routing to it and its services/DNS stop resolving —
+   *functionally* clean before anything is deleted.
+
+2. **Leader-elected reaper (bounded storage).** This generalises the alive service's existing
+   leader-scrub. The elected leader (`utils.Leader(AvailableNodes(...))`) periodically walks
+   the registry and, for each `Liveness` bucket, writes signed tombstones for entries whose
+   owner left the live set. The merge accepts these cross-owner tombstones precisely because
+   the owner's lease is expired (same rule as reclaim). Only the leader writes ⇒ no tombstone
+   storm; if the leader dies, the next election picks a live one.
+
+3. **Tombstone GC.** Tombstones carry an `Absolute` TTL (e.g. 2–3× `maxTime`, wider than any
+   expected partition); past that the leader physically drops the key. A node partitioned
+   longer than that may briefly re-inject an old entry — but its heartbeat is stale too, so
+   readers ignore it and the reaper re-tombstones it next cycle. Self-healing; storage stays
+   bounded.
+
+This replaces the current blunt `b.DeleteBucket(HealthCheckKey)` scrub in `alive.go` with
+targeted, registry-driven reaping across all TTL buckets.
+
+> Implementation note: layers (2) and (3) are implemented (`Ledger.Reap`, wired into the
+> alive service's leader path), and tombstoned entries already read as absent via
+> `GetKey`/`CurrentData`. Layer (1), an explicit `IsLive(owner)` guard inlined at each
+> read site (routing/dial/resolve) for sub-scrub-interval immediacy, is a follow-up — until
+> then a dead owner's entry is skipped as soon as the reaper tombstones it (within one scrub
+> interval), and routing to an already-gone peer simply fails in the meantime.
+
+## 10. Wiring
+
+The ledger is currently created lazily (`node.Ledger()`) before `genHost`. We build the
+`Signer` from the host key right after `genHost` and inject it (`ledger.SetSigner(...)`)
+before any network service runs. The host private key is read from
+`host.Peerstore().PrivKey(host.ID())`, covering both supplied and auto-generated keys.
+
+## 11. Configuration
+
+| Flag / field          | Default     | Meaning                                            |
+|-----------------------|-------------|----------------------------------------------------|
+| `--enforce-ownership` | `false`     | off = sign+verify but log-only; on = drop invalid  |
+| `--ownership-ttl`     | `maxTime`   | liveness window (reuse the existing alive maxtime)  |
+| `--reaper-interval`   | `scrubTime` | how often the leader reaps                          |
+| `--tombstone-ttl`     | `3×ttl`     | how long tombstones are retained before pruning     |
+
+## 12. Backwards compatibility
+
+The wire format gains fields, so a new node and an old node will not agree on the affected
+buckets. Strategy for a single PR:
+
+- New nodes **always sign** their writes and **always verify**, but **enforce only when the
+  flag is on**. With the flag off, an old (unsigned) entry is treated as an unregistered/legacy
+  entry and accepted; a new signed entry is also accepted by old nodes (they ignore the extra
+  fields). This lets a network upgrade node-by-node, observe `WARN`s, then flip enforcement on
+  network-wide.
+- A protocol/version constant is bumped for observability, but it does not hard-gate joining.
+
+## 13. Testing
+
+- `sign_test.go`: sign/verify round-trip; pubkey-from-peerID extraction; any tampered field → reject.
+- `policy_test.go`: registry lookups; `IsLive` against `HealthCheckKey`; `expired` for both kinds.
+- `ledger_merge_test.go`:
+  - legit owner update accepted;
+  - **cross-owner overwrite of a live entry rejected** (the IP-hijack test);
+  - rollback (lower version) rejected;
+  - tombstone not resurrected by replay of the old value;
+  - concurrent first-claim of one IP converges deterministically on all nodes;
+  - reclaim after lease expiry accepted;
+  - log-only mode accepts-but-warns; enforce mode drops.
+- `reaper_test.go`: dead-owner entries get tombstoned by the leader only; tombstones pruned
+  after `tombstone-ttl`.
+- `go test -race ./pkg/blockchain/... ./pkg/node/... ./pkg/services/...`.
+
+## 14. Files touched
+
+`pkg/blockchain/{data,block,ledger,sign(new),policy(new),store_disk,store_memory}.go`,
+`pkg/node/{node,options}.go`, `pkg/config/config.go`, `pkg/services/alive.go` (reaper),
+`pkg/vpn/vpn.go` + `pkg/services/{services,files,dns}.go` (one-line `IsLive` guards on reads),
+`pkg/protocol/protocol.go` (version bump), plus tests.
+
+## 15. Known limitations / follow-ups
+
+- **DNS ownership.** `types.DNS` carries no owner field, so the `dns` bucket is left
+  open (unauthenticated) in this iteration. Closing the DNS-poisoning vector under
+  enforcement requires adding an owner peer.ID to the record, having the dns service
+  stamp it, and (per the chosen policy) first-claim + lease semantics. The registry is
+  the single place to opt it in once that lands.
+- **Reader-side lazy `IsLive` guards.** Implemented reaping + tombstone hiding; the
+  inlined per-read `IsLive(owner)` guard (sub-scrub-interval immediacy) is a follow-up.
+- **Wire format.** Observe/enforce modes change the on-wire entry encoding to the signed
+  object form; a network running observe/enforce must have all nodes on this version.
+  The default (`off`) keeps the exact legacy bare-value encoding, so mixed old/new nodes
+  interoperate only while enforcement is off.
+- **`--enforce-ownership` UX.** Exposed as `--ownership=off|observe|enforce` with
+  `--ownership-ttl`; the recommended rollout is `observe` (logs violations) before
+  `enforce`.

--- a/docs/design/authenticated-ledger.md
+++ b/docs/design/authenticated-ledger.md
@@ -239,6 +239,45 @@ before any network service runs. The host private key is read from
 Reaping cadence reuses the existing alive `scrub-interval`, and tombstones are retained for
 `3×maxtime` before pruning (see `pkg/services/alive.go`).
 
+## 11a. Identity, the token, and restarts
+
+Ownership binds every entry to a peer's **libp2p identity** — which is *not* the network token.
+The two are independent secrets:
+
+- The **token** carries only the OTP material (DHT key, crypto exchange key, room/rendezvous).
+  It is shared by every node and contains no private key. It is *admission* control.
+- The **identity** is a per-node Ed25519 keypair (`genHost`, `pkg/node/connection.go`). It is the
+  thing ownership is bound to. A libp2p Ed25519 peer ID **embeds its public key**, which is what
+  lets `Verify` recover the verifying key from the `Owner` peer.ID with no PKI.
+
+By default the identity is **ephemeral**: with no configured key, `GenPrivKey(0)` draws from
+`crypto/rand`, so the peer ID is fresh on every start. Persistence is via `--privkey-cache`
+(binary) or `node.WithPrivKey` (library).
+
+**Why this matters under enforcement.** Because entries are owned by the identity:
+
+- *Stable identity* → a restart is the **same owner**; the node updates its own entries
+  immediately (same-owner write, version kept monotonic by the wall-clock floor in
+  `versionAfter`). No orphans, no reclaim delay.
+- *Ephemeral identity* → a restart is a **new owner**; the node's previous entries are orphaned,
+  reaped after the liveness TTL, and the node re-establishes its footprint under the new identity
+  via cross-owner reclaim (allowed only once the old owner expires). This works but adds churn and
+  a reclaim delay of up to the TTL on every restart.
+
+For this reason the binary **auto-enables identity persistence whenever ownership is on**
+(`enforce`/`observe`): `cmd/util.go` reads/creates `<privkey-cache-dir>/privkey` even without an
+explicit `--privkey-cache`, and warns (rather than failing) if it cannot persist, so an operator
+who has not opted into stable identities still gets clean restarts under enforcement.
+
+**Security boundary.** Token = admission (keeps outsiders out); identity = per-write integrity
+(keeps insiders from impersonating each other — a leaked token still cannot let peer A write peer
+B's entries, since that needs B's private key, which is never shared and never in the token).
+The flip side: identities are free and unlimited, so ownership gives **write-integrity, not
+anti-sybil**. A token-holding attacker can still spin up many identities and *first-claim* free
+IPs / service names / DNS names (ownership stops hijacking *existing* entries, not squatting
+*unclaimed* ones). Anti-sybil needs an identity cost/allowlist — which is what the
+`PeerGuard`/trustzone ECDSA mechanism is for.
+
 ## 12. Backwards compatibility
 
 The signed wire format differs from the legacy bare-value one, so observe/enforce nodes do not

--- a/docs/design/authenticated-ledger.md
+++ b/docs/design/authenticated-ledger.md
@@ -1,6 +1,6 @@
 # Authenticated, per-owner ledger entries
 
-Status: **proposed** · Target: single PR · Default behaviour: **unchanged** until `--enforce-ownership` is set.
+Status: **proposed** · Target: single PR · The `edgevpn` binary defaults to `--ownership=enforce`; operators opt out with `--ownership=off` (`EDGEVPNOWNERSHIP`). The library default (`node.New` without the option) stays off so embedders opt in deliberately.
 
 ## 1. Problem
 
@@ -174,9 +174,9 @@ for each (bucket, key, incoming) in block.Storage:
 - **Cross-owner writes are allowed iff the current owner's lease has expired.** This single
   rule powers both *reclaim* (peer B takes a dead peer's IP) and *reaping* (the leader
   tombstones a dead peer's entry).
-- **`--enforce-ownership` dual mode**: when **off** (default), every `drop` above is instead
-  a `WARN` log + accept (so operators can observe violations on a live network without
-  breaking it); when **on**, drops are enforced. Verification and signing always run.
+- **Modes**: `off` skips this merge entirely (legacy height-wins path, no signing). `observe`
+  runs the merge but turns every `drop` above into a `WARN` log + accept (observe violations on
+  a live network without breaking it). `enforce` (the binary default) drops invalid writes.
 
 ## 8. Write path
 
@@ -231,24 +231,28 @@ before any network service runs. The host private key is read from
 
 ## 11. Configuration
 
-| Flag / field          | Default     | Meaning                                            |
-|-----------------------|-------------|----------------------------------------------------|
-| `--enforce-ownership` | `false`     | off = sign+verify but log-only; on = drop invalid  |
-| `--ownership-ttl`     | `maxTime`   | liveness window (reuse the existing alive maxtime)  |
-| `--reaper-interval`   | `scrubTime` | how often the leader reaps                          |
-| `--tombstone-ttl`     | `3×ttl`     | how long tombstones are retained before pruning     |
+| Flag / field             | Default   | Meaning                                               |
+|--------------------------|-----------|-------------------------------------------------------|
+| `--ownership` (`EDGEVPNOWNERSHIP`) | `enforce` | `enforce` = sign + reject; `observe` = sign + log-only; `off` = legacy/opt-out |
+| `--ownership-ttl`        | node default (2m) | liveness window after which an inactive owner's entries may be reclaimed/reaped |
+
+Reaping cadence reuses the existing alive `scrub-interval`, and tombstones are retained for
+`3×maxtime` before pruning (see `pkg/services/alive.go`).
 
 ## 12. Backwards compatibility
 
-The wire format gains fields, so a new node and an old node will not agree on the affected
-buckets. Strategy for a single PR:
+The signed wire format differs from the legacy bare-value one, so observe/enforce nodes do not
+interoperate with pre-authentication nodes on the owned buckets. Because the binary now
+defaults to `enforce`, **a network must be upgraded together** (all nodes on the same version
+and mode). Notes:
 
-- New nodes **always sign** their writes and **always verify**, but **enforce only when the
-  flag is on**. With the flag off, an old (unsigned) entry is treated as an unregistered/legacy
-  entry and accepted; a new signed entry is also accepted by old nodes (they ignore the extra
-  fields). This lets a network upgrade node-by-node, observe `WARN`s, then flip enforcement on
-  network-wide.
-- A protocol/version constant is bumped for observability, but it does not hard-gate joining.
+- The library default (`node.New` without `WithOwnership`) stays `off`, emitting the exact
+  legacy bare-value encoding, so embedders (e.g. LocalAI, Kairos) are unaffected until they
+  opt in — and they must ensure the alive service is running, since cross-owner protection
+  relies on heartbeats.
+- `observe` is the safe rollout step: it signs and logs violations without dropping, so a
+  network can move legacy → observe → enforce while watching the warnings.
+- Operators opt out with `--ownership=off` (`EDGEVPNOWNERSHIP=off`).
 
 ## 13. Testing
 

--- a/docs/design/authenticated-ledger.md
+++ b/docs/design/authenticated-ledger.md
@@ -277,6 +277,32 @@ and mode). Notes:
 `pkg/vpn/vpn.go` + `pkg/services/{services,files,dns}.go` (one-line `IsLive` guards on reads),
 `pkg/protocol/protocol.go` (version bump), plus tests.
 
+## 14a. Post-review hardening
+
+A review of the first cut found and fixed several issues:
+
+- **No re-broadcast churn / false warnings.** The merge now skips byte-identical
+  incoming entries (`sameEntry`), so an idle network neither mints a block every
+  sync nor logs spurious ownership-violation warnings; open buckets require a
+  *strictly* higher version to adopt.
+- **Restart-safe versioning.** Versions are floored to the wall clock
+  (`versionAfter`), and an existing tombstone is treated as a reclaimable slot,
+  so an owner that restarts (or returns after being reaped) is not locked out of
+  its own key by a higher-versioned tombstone until GC.
+- **Atomic writes.** `commit` holds the lock across the whole read-modify-write
+  (read → mutate copy → append block), so the concurrent writers — local `Add`,
+  the network merge, and the reaper — can no longer clobber one another (a lost
+  heartbeat could otherwise trigger false reaping). The network merge installs
+  without re-broadcasting (the Syncronizer propagates state) to avoid gossip
+  amplification.
+- **More gated reads.** `IsOwnerLive` now also guards the service-consumer dial
+  (`ConnectNetworkService`) and the file-pull dial (`ReceiveFile`), matching VPN
+  routing. The `egress` bucket is registered (self-owned) so egress
+  advertisements can't be forged for other peers. The `dhcp` leader bucket is
+  deliberately left open (its shared key changes owner on handoff; the
+  deterministic `utils.Leader` cross-check already bounds a forged value to a
+  self-correcting stall, and the assigned IPs in `machines` are signed).
+
 ## 15. Known limitations / follow-ups
 
 - **DNS ownership.** Implemented as a self-owned bucket (first-claim + lease), so

--- a/docs/design/authenticated-ledger.md
+++ b/docs/design/authenticated-ledger.md
@@ -338,9 +338,13 @@ A review of the first cut found and fixed several issues:
   heartbeat could otherwise trigger false reaping). The network merge installs
   without re-broadcasting (the Syncronizer propagates state) to avoid gossip
   amplification.
-- **More gated reads.** `IsOwnerLive` now also guards the service-consumer dial
-  (`ConnectNetworkService`) and the file-pull dial (`ReceiveFile`), matching VPN
-  routing. The `egress` bucket is registered (self-owned) so egress
+- **More gated reads.** `IsOwnerLive` guards VPN routing (high-frequency, where
+  acting on a just-departed owner matters and reaper lag is visible). It is
+  deliberately *not* applied to the one-shot service/file dials: those are
+  short-lived transfers where the peer has just announced itself and is actively
+  serving, so gating on heartbeat propagation only adds latency/fragility — the
+  reaper still removes a dead owner's entry within a scrub interval. The `egress`
+  bucket is registered (self-owned) so egress
   advertisements can't be forged for other peers. The `dhcp` leader bucket is
   deliberately left open (its shared key changes owner on handoff; the
   deterministic `utils.Leader` cross-check already bounds a forged value to a

--- a/pkg/blockchain/block.go
+++ b/pkg/blockchain/block.go
@@ -26,7 +26,7 @@ type DataString string
 type Block struct {
 	Index     int
 	Timestamp string
-	Storage   map[string]map[string]Data
+	Storage   map[string]map[string]SignedData
 	Hash      string
 	PrevHash  string
 }
@@ -61,7 +61,7 @@ func (b Block) Checksum() string {
 }
 
 // create a new block using previous block's hash
-func (oldBlock Block) NewBlock(s map[string]map[string]Data) Block {
+func (oldBlock Block) NewBlock(s map[string]map[string]SignedData) Block {
 	var newBlock Block
 
 	t := time.Now().UTC()

--- a/pkg/blockchain/blockchain_suite_test.go
+++ b/pkg/blockchain/blockchain_suite_test.go
@@ -1,0 +1,26 @@
+/*
+Copyright © 2021-2022 Ettore Di Giacinto <mudler@mocaccino.org>
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blockchain
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestBlockchain(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Blockchain Suite")
+}

--- a/pkg/blockchain/data.go
+++ b/pkg/blockchain/data.go
@@ -13,7 +13,10 @@ limitations under the License.
 
 package blockchain
 
-import "encoding/json"
+import (
+	"bytes"
+	"encoding/json"
+)
 
 type Data string
 
@@ -21,4 +24,50 @@ type Data string
 // set with SetValue
 func (d Data) Unmarshal(i interface{}) error {
 	return json.Unmarshal([]byte(d), i)
+}
+
+// SignedData is a ledger entry authenticated by its author. The Value is the
+// original JSON payload (readers still call Value.Unmarshal); the remaining
+// fields bind that value to the owning peer and a monotonic version so that
+// only the owner can update it and an older value cannot be replayed over a
+// newer one. See docs/design/authenticated-ledger.md.
+type SignedData struct {
+	Value     Data   // original JSON payload
+	Owner     string // peer.ID (base58) of the author
+	Version   uint64 // monotonic per (bucket,key); bumps only when Value changes
+	UpdatedAt int64  // unix seconds, signed; drives TTL/lease renewal
+	Deleted   bool   // signed tombstone marker
+	Sig       []byte // signature over canonical(bucket,key,...)
+}
+
+// signedDataAlias avoids infinite recursion in (Un)MarshalJSON.
+type signedDataAlias SignedData
+
+// MarshalJSON keeps unsigned entries on the legacy wire format (a bare JSON
+// value), so nodes that predate authentication can still decode them. Signed
+// entries are encoded as the full object.
+func (d SignedData) MarshalJSON() ([]byte, error) {
+	if d.Owner == "" && d.Sig == nil && !d.Deleted && d.Version == 0 {
+		return json.Marshal(string(d.Value))
+	}
+	return json.Marshal(signedDataAlias(d))
+}
+
+// UnmarshalJSON accepts either the legacy bare value or the full signed object.
+func (d *SignedData) UnmarshalJSON(b []byte) error {
+	t := bytes.TrimSpace(b)
+	if len(t) > 0 && t[0] != '{' {
+		var s string
+		if err := json.Unmarshal(b, &s); err != nil {
+			return err
+		}
+		d.Value = Data(s)
+		return nil
+	}
+	var a signedDataAlias
+	if err := json.Unmarshal(b, &a); err != nil {
+		return err
+	}
+	*d = SignedData(a)
+	return nil
 }

--- a/pkg/blockchain/json_test.go
+++ b/pkg/blockchain/json_test.go
@@ -15,46 +15,42 @@ package blockchain
 
 import (
 	"encoding/json"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-// An unsigned entry must serialise to the exact pre-authentication wire format
-// (a bare JSON value), so existing nodes that decode Storage values as plain
-// strings keep working.
-func TestSignedDataLegacyWireFormat(t *testing.T) {
-	d := SignedData{Value: Data(`{"PeerID":"x"}`)}
+var _ = Describe("SignedData wire format", func() {
+	// An unsigned entry must serialise to the exact pre-authentication wire
+	// format (a bare JSON value), so existing nodes that decode Storage values
+	// as plain strings keep working.
+	It("keeps unsigned entries on the legacy bare-value format", func() {
+		d := SignedData{Value: Data(`{"PeerID":"x"}`)}
 
-	got, err := json.Marshal(d)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	want, _ := json.Marshal(`{"PeerID":"x"}`) // legacy: Data is a string -> JSON string
-	if string(got) != string(want) {
-		t.Fatalf("legacy marshal = %s, want %s", got, want)
-	}
+		got, err := json.Marshal(d)
+		Expect(err).NotTo(HaveOccurred())
+		want, _ := json.Marshal(`{"PeerID":"x"}`) // legacy: Data is a string -> JSON string
+		Expect(string(got)).To(Equal(string(want)))
 
-	var back SignedData
-	if err := json.Unmarshal(got, &back); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if back.Value != d.Value || back.Owner != "" || back.Version != 0 {
-		t.Fatalf("legacy round-trip mismatch: %+v", back)
-	}
-}
+		var back SignedData
+		Expect(json.Unmarshal(got, &back)).To(Succeed())
+		Expect(back.Value).To(Equal(d.Value))
+		Expect(back.Owner).To(BeEmpty())
+		Expect(back.Version).To(BeZero())
+	})
 
-func TestSignedDataSignedWireRoundTrip(t *testing.T) {
-	d := SignedData{Value: Data(`"v"`), Owner: "peerX", Version: 3, UpdatedAt: 100, Sig: []byte{1, 2, 3}}
+	It("round-trips a signed entry as the full object", func() {
+		d := SignedData{Value: Data(`"v"`), Owner: "peerX", Version: 3, UpdatedAt: 100, Sig: []byte{1, 2, 3}}
 
-	b, err := json.Marshal(d)
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	var back SignedData
-	if err := json.Unmarshal(b, &back); err != nil {
-		t.Fatalf("unmarshal: %v", err)
-	}
-	if back.Owner != "peerX" || back.Version != 3 || back.UpdatedAt != 100 ||
-		string(back.Sig) != string([]byte{1, 2, 3}) || back.Value != d.Value {
-		t.Fatalf("signed round-trip mismatch: %+v", back)
-	}
-}
+		b, err := json.Marshal(d)
+		Expect(err).NotTo(HaveOccurred())
+
+		var back SignedData
+		Expect(json.Unmarshal(b, &back)).To(Succeed())
+		Expect(back.Owner).To(Equal("peerX"))
+		Expect(back.Version).To(Equal(uint64(3)))
+		Expect(back.UpdatedAt).To(Equal(int64(100)))
+		Expect(back.Sig).To(Equal([]byte{1, 2, 3}))
+		Expect(back.Value).To(Equal(d.Value))
+	})
+})

--- a/pkg/blockchain/json_test.go
+++ b/pkg/blockchain/json_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright © 2021-2022 Ettore Di Giacinto <mudler@mocaccino.org>
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blockchain
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// An unsigned entry must serialise to the exact pre-authentication wire format
+// (a bare JSON value), so existing nodes that decode Storage values as plain
+// strings keep working.
+func TestSignedDataLegacyWireFormat(t *testing.T) {
+	d := SignedData{Value: Data(`{"PeerID":"x"}`)}
+
+	got, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	want, _ := json.Marshal(`{"PeerID":"x"}`) // legacy: Data is a string -> JSON string
+	if string(got) != string(want) {
+		t.Fatalf("legacy marshal = %s, want %s", got, want)
+	}
+
+	var back SignedData
+	if err := json.Unmarshal(got, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.Value != d.Value || back.Owner != "" || back.Version != 0 {
+		t.Fatalf("legacy round-trip mismatch: %+v", back)
+	}
+}
+
+func TestSignedDataSignedWireRoundTrip(t *testing.T) {
+	d := SignedData{Value: Data(`"v"`), Owner: "peerX", Version: 3, UpdatedAt: 100, Sig: []byte{1, 2, 3}}
+
+	b, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var back SignedData
+	if err := json.Unmarshal(b, &back); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if back.Owner != "peerX" || back.Version != 3 || back.UpdatedAt != 100 ||
+		string(back.Sig) != string([]byte{1, 2, 3}) || back.Value != d.Value {
+		t.Fatalf("signed round-trip mismatch: %+v", back)
+	}
+}

--- a/pkg/blockchain/ledger.go
+++ b/pkg/blockchain/ledger.go
@@ -483,7 +483,11 @@ func (l *Ledger) CurrentData() map[string]map[string]Data {
 
 	out := map[string]map[string]Data{}
 	for b, kv := range l.blockchain.Last().Storage {
-		out[b] = projectValues(kv)
+		// Omit buckets with no live keys so a fully-tombstoned bucket disappears,
+		// matching the legacy DeleteBucket semantics (the bucket goes away).
+		if p := projectValues(kv); len(p) > 0 {
+			out[b] = p
+		}
 	}
 	return out
 }

--- a/pkg/blockchain/ledger.go
+++ b/pkg/blockchain/ledger.go
@@ -295,8 +295,10 @@ func (l *Ledger) accept(bucket, key string, in, ex SignedData, exists bool, pol 
 		return ""
 	}
 
-	// The value must declare the signer as its owner.
-	if pol.OwnerOf(key, in.Value) != in.Owner {
+	// For buckets whose value declares an owner, it must match the signer. A
+	// nil OwnerOf marks a self-owned bucket (e.g. dns): the value carries no
+	// owner, so the signer is the owner and the key is claimed first-come.
+	if pol.OwnerOf != nil && pol.OwnerOf(key, in.Value) != in.Owner {
 		return "value owner does not match signer"
 	}
 
@@ -330,7 +332,7 @@ func (l *Ledger) expired(bucket, key string, ex SignedData, pol BucketPolicy, he
 		return time.Unix(ex.UpdatedAt, 0).Add(pol.TTL).Before(now)
 	case Liveness:
 		owner := ex.Owner
-		if owner == "" {
+		if owner == "" && pol.OwnerOf != nil {
 			owner = pol.OwnerOf(key, ex.Value)
 		}
 		return !IsLive(health, owner, l.ttl, now)

--- a/pkg/blockchain/ledger.go
+++ b/pkg/blockchain/ledger.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/mudler/edgevpn/pkg/hub"
+	"github.com/mudler/edgevpn/pkg/protocol"
 	"github.com/mudler/edgevpn/pkg/utils"
 
 	"github.com/pkg/errors"
@@ -35,7 +36,30 @@ type Ledger struct {
 	blockchain Store
 
 	channel io.Writer
+
+	// Authentication / ownership (see docs/design/authenticated-ledger.md).
+	// When signer is set, writes are signed; the mode controls whether Update
+	// runs the authorized merge and whether violations are dropped or logged.
+	signer   Signer
+	mode     OwnershipMode
+	registry Registry
+	ttl      time.Duration
+	clock    func() time.Time
+	warn     func(string, ...interface{})
 }
+
+// OwnershipMode selects how the ledger handles authenticated buckets.
+type OwnershipMode int
+
+const (
+	// OwnershipOff: legacy height-wins replace; entries unsigned (default).
+	OwnershipOff OwnershipMode = iota
+	// OwnershipObserve: run the authorized merge but accept-and-warn on
+	// violations instead of dropping (safe rollout / observation).
+	OwnershipObserve
+	// OwnershipEnforce: run the authorized merge and drop invalid writes.
+	OwnershipEnforce
+)
 
 type Store interface {
 	Add(Block)
@@ -43,9 +67,64 @@ type Store interface {
 	Last() Block
 }
 
+// LedgerOption configures optional ledger behaviour.
+type LedgerOption func(*Ledger)
+
+// WithSigner makes the ledger sign every write with s. Without enforcement this
+// only annotates entries (so a network can pre-sign before flipping enforcement
+// on); with enforcement it is required for the local node to author entries.
+func WithSigner(s Signer) LedgerOption { return func(l *Ledger) { l.signer = s } }
+
+// WithOwnership switches Update to the per-key authorized merge using the given
+// policy registry, liveness window and mode (observe = log-only, enforce = drop).
+func WithOwnership(mode OwnershipMode, r Registry, ttl time.Duration) LedgerOption {
+	return func(l *Ledger) {
+		l.mode = mode
+		l.registry = r
+		l.ttl = ttl
+	}
+}
+
+// WithEnforcedOwnership is shorthand for WithOwnership(OwnershipEnforce, ...).
+func WithEnforcedOwnership(r Registry, ttl time.Duration) LedgerOption {
+	return WithOwnership(OwnershipEnforce, r, ttl)
+}
+
+// WithViolationLogger sets the sink for ownership-violation warnings.
+func WithViolationLogger(f func(string, ...interface{})) LedgerOption {
+	return func(l *Ledger) { l.warn = f }
+}
+
+// WithClock overrides the time source (tests).
+func WithClock(f func() time.Time) LedgerOption { return func(l *Ledger) { l.clock = f } }
+
+// SetSigner installs the signing key (called once the host identity exists).
+func (l *Ledger) SetSigner(s Signer) {
+	l.Lock()
+	l.signer = s
+	l.Unlock()
+}
+
+// SetOwnership configures the merge mode/registry/ttl at runtime (called during
+// node startup before the message hub is running).
+func (l *Ledger) SetOwnership(mode OwnershipMode, r Registry, ttl time.Duration) {
+	l.Lock()
+	l.mode, l.registry, l.ttl = mode, r, ttl
+	l.Unlock()
+}
+
 // New returns a new ledger which writes to the writer
-func New(w io.Writer, s Store) *Ledger {
-	c := &Ledger{channel: w, blockchain: s}
+func New(w io.Writer, s Store, opts ...LedgerOption) *Ledger {
+	c := &Ledger{channel: w, blockchain: s, clock: time.Now, warn: log.Printf}
+	for _, o := range opts {
+		o(c)
+	}
+	if c.clock == nil {
+		c.clock = time.Now
+	}
+	if c.warn == nil {
+		c.warn = log.Printf
+	}
 	if s.Len() == 0 {
 		c.newGenesis()
 	}
@@ -53,9 +132,9 @@ func New(w io.Writer, s Store) *Ledger {
 }
 
 func (l *Ledger) newGenesis() {
-	t := time.Now()
+	t := l.clock()
 	genesisBlock := Block{}
-	genesisBlock = Block{0, t.String(), map[string]map[string]Data{}, genesisBlock.Checksum(), ""}
+	genesisBlock = Block{0, t.String(), map[string]map[string]SignedData{}, genesisBlock.Checksum(), ""}
 	l.blockchain.Add(genesisBlock)
 }
 
@@ -108,7 +187,6 @@ func deCompress(b []byte) (*bytes.Buffer, error) {
 
 // Update the blockchain from a message
 func (l *Ledger) Update(f *Ledger, h *hub.Message, c chan *hub.Message) (err error) {
-	//chain := make(Blockchain, 0)
 	block := &Block{}
 
 	b, err := deCompress([]byte(h.Message))
@@ -123,26 +201,142 @@ func (l *Ledger) Update(f *Ledger, h *hub.Message, c chan *hub.Message) (err err
 		return
 	}
 
-	l.Lock()
-	// Adopt the incoming block when it is higher (height wins), or — on an
-	// exact height tie — when its hash sorts higher. The tie-break is what lets
-	// two ledgers that independently climbed to the same index with different
-	// data converge: with `>` alone each node rejects the other's equal-height
-	// block forever (split-brain — e.g. two peers that start simultaneously and
-	// advertise in lockstep). The comparison is deterministic, so every node
-	// picks the same winner and it cannot flip-flop; the loser re-adds its own
-	// data on the next Announce, which raises the index and is then adopted via
-	// the height rule. This is still a whole-block replace (not a merge), so
-	// deletions keep propagating through a higher index and nothing previously
-	// deleted is resurrected.
-	last := l.blockchain.Last()
-	if block.Index > last.Index ||
-		(block.Index == last.Index && block.Hash > last.Hash) {
-		l.blockchain.Add(*block)
+	if l.mode == OwnershipOff {
+		l.Lock()
+		// Legacy path: adopt the incoming block when it is higher (height wins),
+		// or — on an exact height tie — when its hash sorts higher. This is a
+		// whole-block replace and is the behaviour when ownership enforcement is
+		// disabled (the default), keeping existing networks unchanged.
+		last := l.blockchain.Last()
+		if block.Index > last.Index ||
+			(block.Index == last.Index && block.Hash > last.Hash) {
+			l.blockchain.Add(*block)
+		}
+		l.Unlock()
+		return
 	}
+
+	// Enforced path: authenticated per-key merge.
+	l.Lock()
+	cur := copyStorage(l.blockchain.Last().Storage)
+	now := l.clock()
 	l.Unlock()
 
+	if merged, changed := l.merge(cur, block, now); changed {
+		l.writeData(merged)
+	}
 	return
+}
+
+// merge applies each entry of an incoming block into cur, enforcing the
+// per-bucket ownership policy. Returns the merged storage and whether anything
+// changed.
+func (l *Ledger) merge(cur map[string]map[string]SignedData, incoming *Block, now time.Time) (map[string]map[string]SignedData, bool) {
+	health := projectValues(cur[protocol.HealthCheckKey])
+	changed := false
+
+	for bucket, kv := range incoming.Storage {
+		pol := l.registry.Policy(bucket)
+		for key, in := range kv {
+			if cur[bucket] == nil {
+				cur[bucket] = map[string]SignedData{}
+			}
+			ex, ok := cur[bucket][key]
+
+			if !pol.Owned {
+				// Open/legacy bucket: take the highest version, else keep.
+				if !ok || in.Version >= ex.Version {
+					cur[bucket][key] = in
+					changed = true
+				}
+				continue
+			}
+
+			if reason := l.accept(bucket, key, in, ex, ok, pol, health, now); reason != "" {
+				// Rejected by policy. In observe mode we log and accept anyway so
+				// operators can see violations without breaking a live network.
+				if l.mode == OwnershipObserve {
+					l.warn("ownership violation (observe, accepting): %s/%s from %s: %s", bucket, key, in.Owner, reason)
+					cur[bucket][key] = in
+					changed = true
+				} else {
+					l.warn("ownership violation (rejected): %s/%s from %s: %s", bucket, key, in.Owner, reason)
+				}
+				continue
+			}
+			cur[bucket][key] = in
+			changed = true
+		}
+	}
+	return cur, changed
+}
+
+// accept decides whether an authenticated entry may overwrite the existing one.
+// It returns "" to accept, or a short reason describing the rejection.
+func (l *Ledger) accept(bucket, key string, in, ex SignedData, exists bool, pol BucketPolicy, health map[string]Data, now time.Time) string {
+	// Signature must be valid and bound to the claimed owner.
+	if err := Verify(bucket, key, in); err != nil {
+		return "invalid signature"
+	}
+
+	if in.Deleted {
+		// A tombstone may be authored by the current owner, or by anyone once
+		// the current owner's lease has expired (the reaper). It must out-version
+		// what it deletes.
+		if !exists {
+			return "tombstone for unknown key"
+		}
+		if in.Owner != ex.Owner && !l.expired(bucket, key, ex, pol, health, now) {
+			return "tombstone by non-owner of a live entry"
+		}
+		if in.Version <= ex.Version {
+			return "stale tombstone"
+		}
+		return ""
+	}
+
+	// The value must declare the signer as its owner.
+	if pol.OwnerOf(key, in.Value) != in.Owner {
+		return "value owner does not match signer"
+	}
+
+	if !exists {
+		return "" // first claim of a free key
+	}
+
+	// A different owner may only take over an expired (or reclaimable-free) slot.
+	if in.Owner != ex.Owner && !l.expired(bucket, key, ex, pol, health, now) {
+		return "overwrite of a live entry owned by another peer"
+	}
+
+	if in.Version < ex.Version {
+		return "rollback to an older version"
+	}
+	if in.Version == ex.Version {
+		// Deterministic tie-break so every node converges on the same winner.
+		if in.Owner > ex.Owner || (in.Owner == ex.Owner && string(in.Sig) > string(ex.Sig)) {
+			return ""
+		}
+		return "lost deterministic tie-break"
+	}
+	return ""
+}
+
+// expired reports whether the existing entry is past its lease and may be taken
+// over by another owner.
+func (l *Ledger) expired(bucket, key string, ex SignedData, pol BucketPolicy, health map[string]Data, now time.Time) bool {
+	switch pol.Expiry {
+	case Absolute:
+		return time.Unix(ex.UpdatedAt, 0).Add(pol.TTL).Before(now)
+	case Liveness:
+		owner := ex.Owner
+		if owner == "" {
+			owner = pol.OwnerOf(key, ex.Value)
+		}
+		return !IsLive(health, owner, l.ttl, now)
+	default:
+		return false
+	}
 }
 
 // Announce keeps updating async data to the blockchain.
@@ -151,7 +345,6 @@ func (l *Ledger) Update(f *Ledger, h *hub.Message, c chan *hub.Message) (err err
 // blockchain
 func (l *Ledger) Announce(ctx context.Context, d time.Duration, async func()) {
 	go func() {
-		//t := time.NewTicker(t)
 		t := utils.NewBackoffTicker(utils.BackoffMaxInterval(d))
 		defer t.Stop()
 		for {
@@ -232,13 +425,15 @@ func (l *Ledger) GetKey(b, s string) (value Data, exists bool) {
 
 	if l.blockchain.Len() > 0 {
 		last := l.blockchain.Last()
-		if _, exists = last.Storage[b]; !exists {
+		bkt, ok := last.Storage[b]
+		if !ok {
 			return
 		}
-		value, exists = last.Storage[b][s]
-		if exists {
+		e, ok := bkt[s]
+		if !ok || e.Deleted {
 			return
 		}
+		return e.Value, true
 	}
 	return
 }
@@ -249,7 +444,10 @@ func (l *Ledger) Exists(b string, f func(Data) bool) (exists bool) {
 	defer l.Unlock()
 	if l.blockchain.Len() > 0 {
 		for _, bv := range l.blockchain.Last().Storage[b] {
-			if f(bv) {
+			if bv.Deleted {
+				continue
+			}
+			if f(bv.Value) {
 				exists = true
 				return
 			}
@@ -259,12 +457,25 @@ func (l *Ledger) Exists(b string, f func(Data) bool) (exists bool) {
 	return
 }
 
-// CurrentData returns the current ledger data (locking)
+// CurrentData returns the current ledger data (locking). Tombstoned entries are
+// hidden and only the inner Value is exposed, so existing readers are unchanged.
 func (l *Ledger) CurrentData() map[string]map[string]Data {
 	l.Lock()
 	defer l.Unlock()
 
-	return buckets(l.blockchain.Last().Storage).copy()
+	out := map[string]map[string]Data{}
+	for b, kv := range l.blockchain.Last().Storage {
+		out[b] = projectValues(kv)
+	}
+	return out
+}
+
+// CurrentStorage returns a deep copy of the raw signed storage (locking). Used
+// by the reaper, which needs owner/version metadata.
+func (l *Ledger) CurrentStorage() map[string]map[string]SignedData {
+	l.Lock()
+	defer l.Unlock()
+	return copyStorage(l.blockchain.Last().Storage)
 }
 
 // LastBlock returns the last block in the blockchain
@@ -274,79 +485,112 @@ func (l *Ledger) LastBlock() Block {
 	return l.blockchain.Last()
 }
 
-type bucket map[string]Data
-
-func (b bucket) copy() map[string]Data {
-	copy := map[string]Data{}
-	for k, v := range b {
-		copy[k] = v
+func copyStorage(s map[string]map[string]SignedData) map[string]map[string]SignedData {
+	out := map[string]map[string]SignedData{}
+	for b, kv := range s {
+		nb := make(map[string]SignedData, len(kv))
+		for k, v := range kv {
+			nb[k] = v
+		}
+		out[b] = nb
 	}
-	return copy
+	return out
 }
 
-type buckets map[string]map[string]Data
-
-func (b buckets) copy() map[string]map[string]Data {
-	copy := map[string]map[string]Data{}
-	for k, v := range b {
-		copy[k] = bucket(v).copy()
+// projectValues exposes a bucket's live (non-tombstoned) values.
+func projectValues(kv map[string]SignedData) map[string]Data {
+	out := map[string]Data{}
+	for k, v := range kv {
+		if v.Deleted {
+			continue
+		}
+		out[k] = v.Value
 	}
-	return copy
+	return out
+}
+
+// makeEntry builds the SignedData to store for a write. Without a signer it
+// produces a legacy unsigned/unversioned entry (so the wire format is unchanged
+// for default networks). With a signer it bumps the version and re-signs only
+// when the value actually changes (keeping re-announce idempotent).
+func (l *Ledger) makeEntry(bucket, key string, value Data, prev SignedData, now time.Time) SignedData {
+	if l.signer == nil {
+		return SignedData{Value: value}
+	}
+	if prev.Owner == l.signer.ID() && !prev.Deleted && prev.Value == value && prev.Sig != nil {
+		return prev
+	}
+	d := SignedData{Value: value, Version: prev.Version + 1, UpdatedAt: now.Unix(), Owner: l.signer.ID()}
+	d.Sig, _ = l.signer.Sign(canonical(bucket, key, d))
+	return d
+}
+
+func (l *Ledger) makeTombstone(bucket, key string, prev SignedData, now time.Time) SignedData {
+	d := SignedData{Owner: l.signer.ID(), Version: prev.Version + 1, UpdatedAt: now.Unix(), Deleted: true}
+	d.Sig, _ = l.signer.Sign(canonical(bucket, key, d))
+	return d
 }
 
 // Add data to the blockchain
 func (l *Ledger) Add(b string, s map[string]interface{}) {
 	l.Lock()
-	current := buckets(l.blockchain.Last().Storage).copy()
-
-	for s, k := range s {
+	current := copyStorage(l.blockchain.Last().Storage)
+	now := l.clock()
+	for key, val := range s {
 		if _, exists := current[b]; !exists {
-			current[b] = make(map[string]Data)
+			current[b] = make(map[string]SignedData)
 		}
-		dat, _ := json.Marshal(k)
-		current[b][s] = Data(string(dat))
+		dat, _ := json.Marshal(val)
+		current[b][key] = l.makeEntry(b, key, Data(string(dat)), current[b][key], now)
 	}
 	l.Unlock()
 	l.writeData(current)
 }
 
-// Delete data from the ledger (locking)
+// Delete data from the ledger (locking). With a signer this writes a signed
+// tombstone so the deletion survives gossip reconciliation; without one it
+// removes the key (legacy behaviour).
 func (l *Ledger) Delete(b string, k string) {
 	l.Lock()
-	new := make(map[string]map[string]Data)
-	for bb, kk := range l.blockchain.Last().Storage {
-		if _, exists := new[bb]; !exists {
-			new[bb] = make(map[string]Data)
-		}
-		// Copy all keys/v except b/k
-		for kkk, v := range kk {
-			if !(bb == b && kkk == k) {
-				new[bb][kkk] = v
+	current := copyStorage(l.blockchain.Last().Storage)
+	now := l.clock()
+
+	if l.signer != nil {
+		if bkt, ok := current[b]; ok {
+			if prev, ok := bkt[k]; ok && !prev.Deleted {
+				current[b][k] = l.makeTombstone(b, k, prev, now)
 			}
 		}
+		l.Unlock()
+		l.writeData(current)
+		return
 	}
+
+	delete(current[b], k)
 	l.Unlock()
-	l.writeData(new)
+	l.writeData(current)
 }
 
-// DeleteBucket deletes a bucket from the ledger (locking)
+// DeleteBucket deletes a bucket from the ledger (locking).
 func (l *Ledger) DeleteBucket(b string) {
 	l.Lock()
-	new := make(map[string]map[string]Data)
-	for bb, kk := range l.blockchain.Last().Storage {
-		// Copy all except the specified bucket
-		if bb == b {
-			continue
+	current := copyStorage(l.blockchain.Last().Storage)
+	now := l.clock()
+
+	if l.signer != nil {
+		for k, prev := range current[b] {
+			if !prev.Deleted {
+				current[b][k] = l.makeTombstone(b, k, prev, now)
+			}
 		}
-		if _, exists := new[bb]; !exists {
-			new[bb] = make(map[string]Data)
-		}
-		for kkk, v := range kk {
-			new[bb][kkk] = v
-		}
+		l.Unlock()
+		l.writeData(current)
+		return
 	}
+
+	delete(current, b)
 	l.Unlock()
-	l.writeData(new)
+	l.writeData(current)
 }
 
 // String returns the blockchain as string
@@ -360,7 +604,7 @@ func (l *Ledger) Index() int {
 	return l.blockchain.Len()
 }
 
-func (l *Ledger) writeData(s map[string]map[string]Data) {
+func (l *Ledger) writeData(s map[string]map[string]SignedData) {
 	newBlock := l.blockchain.Last().NewBlock(s)
 
 	if newBlock.IsValid(l.blockchain.Last()) {

--- a/pkg/blockchain/ledger.go
+++ b/pkg/blockchain/ledger.go
@@ -216,15 +216,13 @@ func (l *Ledger) Update(f *Ledger, h *hub.Message, c chan *hub.Message) (err err
 		return
 	}
 
-	// Enforced path: authenticated per-key merge.
-	l.Lock()
-	cur := copyStorage(l.blockchain.Last().Storage)
-	now := l.clock()
-	l.Unlock()
-
-	if merged, changed := l.merge(cur, block, now); changed {
-		l.writeData(merged)
-	}
+	// Enforced path: authenticated per-key merge, applied atomically. We do not
+	// re-broadcast on adoption (the Syncronizer propagates state) to avoid gossip
+	// amplification.
+	l.commit(false, func(cur map[string]map[string]SignedData) bool {
+		_, changed := l.merge(cur, block, l.clock())
+		return changed
+	})
 	return
 }
 
@@ -243,9 +241,16 @@ func (l *Ledger) merge(cur map[string]map[string]SignedData, incoming *Block, no
 			}
 			ex, ok := cur[bucket][key]
 
+			// Idle networks re-broadcast the same block every sync interval, so a
+			// byte-identical incoming entry is the common case: skip it silently
+			// (no new block, no warning).
+			if ok && sameEntry(ex, in) {
+				continue
+			}
+
 			if !pol.Owned {
-				// Open/legacy bucket: take the highest version, else keep.
-				if !ok || in.Version >= ex.Version {
+				// Open/legacy bucket: take the strictly higher version, else keep.
+				if !ok || in.Version > ex.Version {
 					cur[bucket][key] = in
 					changed = true
 				}
@@ -304,6 +309,17 @@ func (l *Ledger) accept(bucket, key string, in, ex SignedData, exists bool, pol 
 
 	if !exists {
 		return "" // first claim of a free key
+	}
+
+	// An existing tombstone is a cleared slot, not a live entry: any valid owner
+	// (incl. the original owner returning after a reap) may re-claim it, subject
+	// only to version monotonicity. Without this, a leader-authored tombstone
+	// would lock the returning owner out until tombstone GC.
+	if ex.Deleted {
+		if in.Version <= ex.Version {
+			return "stale re-claim over tombstone"
+		}
+		return ""
 	}
 
 	// A different owner may only take over an expired (or reclaimable-free) slot.
@@ -499,6 +515,29 @@ func copyStorage(s map[string]map[string]SignedData) map[string]map[string]Signe
 	return out
 }
 
+// sameEntry reports whether two entries are byte-identical (the common case for
+// re-broadcast/relay), so the merge can skip them without churn or warnings.
+func sameEntry(a, b SignedData) bool {
+	return a.Owner == b.Owner &&
+		a.Version == b.Version &&
+		a.UpdatedAt == b.UpdatedAt &&
+		a.Deleted == b.Deleted &&
+		a.Value == b.Value &&
+		bytes.Equal(a.Sig, b.Sig)
+}
+
+// versionAfter returns the next version for a write. It is monotonic per key
+// (prev+1) but also floored to the wall clock, so an owner that restarts with a
+// fresh ledger (version counter reset) still out-versions any stale entry or
+// tombstone other peers retained, rather than being rejected as a rollback.
+func versionAfter(prev uint64, now time.Time) uint64 {
+	v := prev + 1
+	if n := uint64(now.UnixNano()); n > v {
+		return n
+	}
+	return v
+}
+
 // projectValues exposes a bucket's live (non-tombstoned) values.
 func projectValues(kv map[string]SignedData) map[string]Data {
 	out := map[string]Data{}
@@ -522,77 +561,80 @@ func (l *Ledger) makeEntry(bucket, key string, value Data, prev SignedData, now 
 	if prev.Owner == l.signer.ID() && !prev.Deleted && prev.Value == value && prev.Sig != nil {
 		return prev
 	}
-	d := SignedData{Value: value, Version: prev.Version + 1, UpdatedAt: now.Unix(), Owner: l.signer.ID()}
+	d := SignedData{Value: value, Version: versionAfter(prev.Version, now), UpdatedAt: now.Unix(), Owner: l.signer.ID()}
 	d.Sig, _ = l.signer.Sign(canonical(bucket, key, d))
 	return d
 }
 
 func (l *Ledger) makeTombstone(bucket, key string, prev SignedData, now time.Time) SignedData {
-	d := SignedData{Owner: l.signer.ID(), Version: prev.Version + 1, UpdatedAt: now.Unix(), Deleted: true}
+	d := SignedData{Owner: l.signer.ID(), Version: versionAfter(prev.Version, now), UpdatedAt: now.Unix(), Deleted: true}
 	d.Sig, _ = l.signer.Sign(canonical(bucket, key, d))
 	return d
 }
 
 // Add data to the blockchain
 func (l *Ledger) Add(b string, s map[string]interface{}) {
-	l.Lock()
-	current := copyStorage(l.blockchain.Last().Storage)
-	now := l.clock()
-	for key, val := range s {
-		if _, exists := current[b]; !exists {
-			current[b] = make(map[string]SignedData)
+	l.commit(true, func(cur map[string]map[string]SignedData) bool {
+		now := l.clock()
+		if cur[b] == nil {
+			cur[b] = make(map[string]SignedData)
 		}
-		dat, _ := json.Marshal(val)
-		current[b][key] = l.makeEntry(b, key, Data(string(dat)), current[b][key], now)
-	}
-	l.Unlock()
-	l.writeData(current)
+		changed := false
+		for key, val := range s {
+			dat, _ := json.Marshal(val)
+			ne := l.makeEntry(b, key, Data(string(dat)), cur[b][key], now)
+			if prev, ok := cur[b][key]; !ok || !sameEntry(prev, ne) {
+				cur[b][key] = ne
+				changed = true
+			}
+		}
+		return changed
+	})
 }
 
-// Delete data from the ledger (locking). With a signer this writes a signed
-// tombstone so the deletion survives gossip reconciliation; without one it
-// removes the key (legacy behaviour).
+// Delete data from the ledger. With a signer this writes a signed tombstone so
+// the deletion survives gossip reconciliation; without one it removes the key
+// (legacy behaviour).
 func (l *Ledger) Delete(b string, k string) {
-	l.Lock()
-	current := copyStorage(l.blockchain.Last().Storage)
-	now := l.clock()
-
-	if l.signer != nil {
-		if bkt, ok := current[b]; ok {
-			if prev, ok := bkt[k]; ok && !prev.Deleted {
-				current[b][k] = l.makeTombstone(b, k, prev, now)
+	l.commit(true, func(cur map[string]map[string]SignedData) bool {
+		now := l.clock()
+		if l.signer != nil {
+			if bkt, ok := cur[b]; ok {
+				if prev, ok := bkt[k]; ok && !prev.Deleted {
+					cur[b][k] = l.makeTombstone(b, k, prev, now)
+					return true
+				}
 			}
+			return false
 		}
-		l.Unlock()
-		l.writeData(current)
-		return
-	}
-
-	delete(current[b], k)
-	l.Unlock()
-	l.writeData(current)
+		if _, ok := cur[b][k]; ok {
+			delete(cur[b], k)
+			return true
+		}
+		return false
+	})
 }
 
-// DeleteBucket deletes a bucket from the ledger (locking).
+// DeleteBucket deletes a bucket from the ledger.
 func (l *Ledger) DeleteBucket(b string) {
-	l.Lock()
-	current := copyStorage(l.blockchain.Last().Storage)
-	now := l.clock()
-
-	if l.signer != nil {
-		for k, prev := range current[b] {
-			if !prev.Deleted {
-				current[b][k] = l.makeTombstone(b, k, prev, now)
+	l.commit(true, func(cur map[string]map[string]SignedData) bool {
+		now := l.clock()
+		if l.signer != nil {
+			changed := false
+			for k, prev := range cur[b] {
+				if !prev.Deleted {
+					cur[b][k] = l.makeTombstone(b, k, prev, now)
+					changed = true
+				}
 			}
+			return changed
 		}
-		l.Unlock()
-		l.writeData(current)
-		return
-	}
-
-	delete(current, b)
-	l.Unlock()
-	l.writeData(current)
+		if _, ok := cur[b]; ok {
+			delete(cur, b)
+			return true
+		}
+		return false
+	})
 }
 
 // String returns the blockchain as string
@@ -606,19 +648,35 @@ func (l *Ledger) Index() int {
 	return l.blockchain.Len()
 }
 
-func (l *Ledger) writeData(s map[string]map[string]SignedData) {
-	newBlock := l.blockchain.Last().NewBlock(s)
-
-	if newBlock.IsValid(l.blockchain.Last()) {
-		l.Lock()
-		l.blockchain.Add(newBlock)
-		l.Unlock()
+// commit runs mutate under the lock against a copy of the current storage and,
+// iff mutate reports a change, installs the result as a new block. The whole
+// read-modify-write is atomic (holding the lock across read, mutate and append),
+// so concurrent writers — local Add, the network merge and the reaper — cannot
+// clobber each other. The broadcast happens after the lock is released (writing
+// to the message channel under the lock could deadlock against the hub
+// consumer, which drives ledger.Update).
+func (l *Ledger) commit(broadcast bool, mutate func(cur map[string]map[string]SignedData) bool) {
+	l.Lock()
+	cur := copyStorage(l.blockchain.Last().Storage)
+	changed := mutate(cur)
+	if changed {
+		newBlock := l.blockchain.Last().NewBlock(cur)
+		if newBlock.IsValid(l.blockchain.Last()) {
+			l.blockchain.Add(newBlock)
+		}
 	}
-
-	bytes, err := json.Marshal(l.blockchain.Last())
-	if err != nil {
-		log.Println(err)
+	var payload []byte
+	if broadcast && changed {
+		b, err := json.Marshal(l.blockchain.Last())
+		if err != nil {
+			log.Println(err)
+		} else {
+			payload = compress(b).Bytes()
+		}
 	}
+	l.Unlock()
 
-	l.channel.Write(compress(bytes).Bytes())
+	if payload != nil {
+		l.channel.Write(payload)
+	}
 }

--- a/pkg/blockchain/ledger_test.go
+++ b/pkg/blockchain/ledger_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 // msgFor wraps a ledger's last block into the wire form Update expects
-// (gzip-compressed JSON), mirroring what writeData broadcasts.
+// (gzip-compressed JSON), mirroring what the ledger broadcasts.
 func msgFor(l *Ledger) *hub.Message {
 	bb, _ := json.Marshal(l.LastBlock())
 	return hub.NewMessage(compress(bb).String())

--- a/pkg/blockchain/ledger_test.go
+++ b/pkg/blockchain/ledger_test.go
@@ -16,7 +16,9 @@ package blockchain
 import (
 	"encoding/json"
 	"io"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"github.com/mudler/edgevpn/pkg/hub"
 )
@@ -49,87 +51,61 @@ func hasKeys(l *Ledger, keys ...string) bool {
 	return true
 }
 
-// TestUpdateEqualIndexConvergesToUnion is the regression guard for the
-// equal-index split-brain. Two ledgers independently reach the same index with
-// different data (e.g. two peers booted simultaneously, each having advertised
-// once). It asserts the full outcome that matters: after a few exchange +
-// re-announce rounds BOTH ledgers hold BOTH advertisements and agree on the
-// same block.
-//
-// Note the intermediate state: a single Update only makes the loser adopt the
-// winner's block (the loser's key is momentarily gone). The union is reached on
-// the next announce — the loser re-adds its key, Add unions it onto the current
-// (winner's) storage at a higher index, and the winner adopts that via height.
-func TestUpdateEqualIndexConvergesToUnion(t *testing.T) {
-	a := New(io.Discard, &MemoryStore{})
-	b := New(io.Discard, &MemoryStore{})
+var _ = Describe("Legacy merge (ownership off)", func() {
+	// Regression guard for the equal-index split-brain. Two ledgers
+	// independently reach the same index with different data (e.g. two peers
+	// booted simultaneously, each having advertised once). It asserts the full
+	// outcome that matters: after a few exchange + re-announce rounds BOTH
+	// ledgers hold BOTH advertisements and agree on the same block.
+	//
+	// Note the intermediate state: a single Update only makes the loser adopt
+	// the winner's block (the loser's key is momentarily gone). The union is
+	// reached on the next announce — the loser re-adds its key, Add unions it
+	// onto the current (winner's) storage at a higher index, and the winner
+	// adopts that via height.
+	It("converges an equal-index split-brain to the union", func() {
+		a := New(io.Discard, &MemoryStore{})
+		b := New(io.Discard, &MemoryStore{})
 
-	a.Add("nodes", map[string]interface{}{"a": "1"})
-	b.Add("nodes", map[string]interface{}{"b": "1"})
+		a.Add("nodes", map[string]interface{}{"a": "1"})
+		b.Add("nodes", map[string]interface{}{"b": "1"})
 
-	// Precondition: same height, different blocks — the deadlock scenario that
-	// `>`-only rejection could never resolve.
-	if a.LastBlock().Index != b.LastBlock().Index {
-		t.Fatalf("precondition: expected equal index, got %d and %d",
-			a.LastBlock().Index, b.LastBlock().Index)
-	}
-	if a.LastBlock().Hash == b.LastBlock().Hash {
-		t.Fatal("precondition: expected the two blocks to differ")
-	}
+		// Precondition: same height, different blocks — the deadlock scenario
+		// that `>`-only rejection could never resolve.
+		Expect(a.LastBlock().Index).To(Equal(b.LastBlock().Index), "precondition: equal index")
+		Expect(a.LastBlock().Hash).NotTo(Equal(b.LastBlock().Hash), "precondition: differing blocks")
 
-	// Drive a few reconcile rounds (exchange, then each re-announces its own
-	// key). Convergence is reached well within this; extra rounds are no-ops.
-	for i := 0; i < 5; i++ {
-		if err := a.Update(a, msgFor(b), nil); err != nil {
-			t.Fatal(err)
+		// Drive a few reconcile rounds (exchange, then each re-announces its own
+		// key). Convergence is reached well within this; extra rounds are no-ops.
+		for i := 0; i < 5; i++ {
+			Expect(a.Update(a, msgFor(b), nil)).To(Succeed())
+			Expect(b.Update(b, msgFor(a), nil)).To(Succeed())
+			announce(a, "a")
+			announce(b, "b")
 		}
-		if err := b.Update(b, msgFor(a), nil); err != nil {
-			t.Fatal(err)
-		}
-		announce(a, "a")
-		announce(b, "b")
-	}
-	// Final exchange so both observe the latest block.
-	if err := a.Update(a, msgFor(b), nil); err != nil {
-		t.Fatal(err)
-	}
-	if err := b.Update(b, msgFor(a), nil); err != nil {
-		t.Fatal(err)
-	}
+		// Final exchange so both observe the latest block.
+		Expect(a.Update(a, msgFor(b), nil)).To(Succeed())
+		Expect(b.Update(b, msgFor(a), nil)).To(Succeed())
 
-	if !hasKeys(a, "a", "b") {
-		t.Fatalf("node a missing an advertisement: %+v", a.CurrentData()["nodes"])
-	}
-	if !hasKeys(b, "a", "b") {
-		t.Fatalf("node b missing an advertisement: %+v", b.CurrentData()["nodes"])
-	}
-	if a.LastBlock().Hash != b.LastBlock().Hash {
-		t.Fatalf("ledgers did not converge on the same block: a=%s b=%s",
-			a.LastBlock().Hash, b.LastBlock().Hash)
-	}
-}
+		Expect(hasKeys(a, "a", "b")).To(BeTrue(), "node a missing an advertisement")
+		Expect(hasKeys(b, "a", "b")).To(BeTrue(), "node b missing an advertisement")
+		Expect(a.LastBlock().Hash).To(Equal(b.LastBlock().Hash), "ledgers did not converge on the same block")
+	})
 
-// TestUpdateHigherIndexStillWins ensures the height rule (and thus deletion
-// propagation, which works by raising the index) is unchanged by the tie-break.
-func TestUpdateHigherIndexStillWins(t *testing.T) {
-	a := New(io.Discard, &MemoryStore{})
-	b := New(io.Discard, &MemoryStore{})
+	// Ensures the height rule (and thus deletion propagation, which works by
+	// raising the index) is unchanged by the tie-break.
+	It("adopts a strictly higher-index block regardless of hash order", func() {
+		a := New(io.Discard, &MemoryStore{})
+		b := New(io.Discard, &MemoryStore{})
 
-	// b climbs higher than a.
-	a.Add("nodes", map[string]interface{}{"a": "1"})
-	b.Add("nodes", map[string]interface{}{"b": "1"})
-	b.Add("nodes", map[string]interface{}{"b": "2"})
+		// b climbs higher than a.
+		a.Add("nodes", map[string]interface{}{"a": "1"})
+		b.Add("nodes", map[string]interface{}{"b": "1"})
+		b.Add("nodes", map[string]interface{}{"b": "2"})
 
-	if b.LastBlock().Index <= a.LastBlock().Index {
-		t.Fatalf("precondition: expected b higher than a, got %d and %d",
-			b.LastBlock().Index, a.LastBlock().Index)
-	}
+		Expect(b.LastBlock().Index).To(BeNumerically(">", a.LastBlock().Index), "precondition: b higher than a")
 
-	// a receives b's higher block and must adopt it regardless of hash order.
-	if err := a.Update(a, msgFor(b), nil); err != nil {
-		t.Fatal(err)
-	}
-	if a.LastBlock().Hash != b.LastBlock().Hash {
-		t.Fatal("higher-index block was not adopted")
-	}
-}
+		Expect(a.Update(a, msgFor(b), nil)).To(Succeed())
+		Expect(a.LastBlock().Hash).To(Equal(b.LastBlock().Hash), "higher-index block was not adopted")
+	})
+})

--- a/pkg/blockchain/merge_test.go
+++ b/pkg/blockchain/merge_test.go
@@ -1,0 +1,196 @@
+/*
+Copyright © 2021-2022 Ettore Di Giacinto <mudler@mocaccino.org>
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blockchain
+
+import (
+	"encoding/json"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/mudler/edgevpn/pkg/hub"
+	"github.com/mudler/edgevpn/pkg/protocol"
+)
+
+// --- helpers -------------------------------------------------------------
+
+func mkSignedEntry(t *testing.T, s Signer, bucket, key string, value interface{}, version uint64, now time.Time) SignedData {
+	t.Helper()
+	jb, _ := json.Marshal(value)
+	d := SignedData{Value: Data(jb), Owner: s.ID(), Version: version, UpdatedAt: now.Unix()}
+	sig, err := s.Sign(canonical(bucket, key, d))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	d.Sig = sig
+	return d
+}
+
+// feed pushes a block carrying the given entries into the ledger via the same
+// wire path Update consumes from gossip.
+func feed(l *Ledger, entries map[string]map[string]SignedData) {
+	b := l.LastBlock().NewBlock(entries)
+	bb, _ := json.Marshal(b)
+	l.Update(nil, hub.NewMessage(compress(bb).String()), nil)
+}
+
+func enforcedLedger(ttl time.Duration, now time.Time) *Ledger {
+	return New(io.Discard, &MemoryStore{},
+		WithEnforcedOwnership(DefaultRegistry(ttl), ttl),
+		WithClock(func() time.Time { return now }),
+	)
+}
+
+// heartbeat returns a signed healthcheck entry for s as of now.
+func heartbeat(t *testing.T, s Signer, now time.Time) map[string]map[string]SignedData {
+	return map[string]map[string]SignedData{
+		protocol.HealthCheckKey: {
+			s.ID(): mkSignedEntry(t, s, protocol.HealthCheckKey, s.ID(), now.UTC().Format(time.RFC3339), 1, now),
+		},
+	}
+}
+
+func machine(peerID, addr string) map[string]string {
+	return map[string]string{"PeerID": peerID, "Address": addr}
+}
+
+// --- tests ---------------------------------------------------------------
+
+func TestMergeAcceptsOwnerWrite(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	l := enforcedLedger(time.Minute, now)
+	a := newTestSigner(t)
+	ip := "10.1.0.1"
+
+	feed(l, map[string]map[string]SignedData{
+		protocol.MachinesLedgerKey: {ip: mkSignedEntry(t, a, protocol.MachinesLedgerKey, ip, machine(a.ID(), ip), 1, now)},
+	})
+
+	v, found := l.GetKey(protocol.MachinesLedgerKey, ip)
+	if !found {
+		t.Fatal("owner write should be accepted")
+	}
+	var m map[string]string
+	v.Unmarshal(&m)
+	if m["PeerID"] != a.ID() {
+		t.Fatalf("stored owner = %q, want %q", m["PeerID"], a.ID())
+	}
+}
+
+func TestMergeRejectsHijackOfLiveOwner(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	l := enforcedLedger(time.Minute, now)
+	a := newTestSigner(t)
+	b := newTestSigner(t)
+	ip := "10.1.0.1"
+
+	// A is alive and owns the IP.
+	feed(l, heartbeat(t, a, now))
+	feed(l, map[string]map[string]SignedData{
+		protocol.MachinesLedgerKey: {ip: mkSignedEntry(t, a, protocol.MachinesLedgerKey, ip, machine(a.ID(), ip), 1, now)},
+	})
+
+	// B tries to steal the IP with a higher version, validly signed by B.
+	feed(l, map[string]map[string]SignedData{
+		protocol.MachinesLedgerKey: {ip: mkSignedEntry(t, b, protocol.MachinesLedgerKey, ip, machine(b.ID(), ip), 2, now)},
+	})
+
+	v, _ := l.GetKey(protocol.MachinesLedgerKey, ip)
+	var m map[string]string
+	v.Unmarshal(&m)
+	if m["PeerID"] != a.ID() {
+		t.Fatalf("hijack succeeded: owner = %q, want %q (A, who is live)", m["PeerID"], a.ID())
+	}
+}
+
+func TestMergeRejectsRollback(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	l := enforcedLedger(time.Minute, now)
+	a := newTestSigner(t)
+	ip := "10.1.0.1"
+
+	feed(l, map[string]map[string]SignedData{
+		protocol.MachinesLedgerKey: {ip: mkSignedEntry(t, a, protocol.MachinesLedgerKey, ip, machine(a.ID(), "10.9.9.9"), 2, now)},
+	})
+	// Replay an older version of A's own entry.
+	feed(l, map[string]map[string]SignedData{
+		protocol.MachinesLedgerKey: {ip: mkSignedEntry(t, a, protocol.MachinesLedgerKey, ip, machine(a.ID(), "10.0.0.0"), 1, now)},
+	})
+
+	v, _ := l.GetKey(protocol.MachinesLedgerKey, ip)
+	var m map[string]string
+	v.Unmarshal(&m)
+	if m["Address"] != "10.9.9.9" {
+		t.Fatalf("rollback accepted: address = %q, want 10.9.9.9", m["Address"])
+	}
+}
+
+func TestMergeRejectsForgedSignature(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	l := enforcedLedger(time.Minute, now)
+	a := newTestSigner(t)
+	ip := "10.1.0.1"
+
+	e := mkSignedEntry(t, a, protocol.MachinesLedgerKey, ip, machine(a.ID(), ip), 1, now)
+	e.Sig = []byte("garbage")
+	feed(l, map[string]map[string]SignedData{protocol.MachinesLedgerKey: {ip: e}})
+
+	if _, found := l.GetKey(protocol.MachinesLedgerKey, ip); found {
+		t.Fatal("entry with forged signature must be rejected")
+	}
+}
+
+func TestMergeAllowsReclaimAfterOwnerExpired(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	l := enforcedLedger(time.Minute, now)
+	a := newTestSigner(t)
+	b := newTestSigner(t)
+	ip := "10.1.0.1"
+
+	// A owns the IP but has NO heartbeat -> not live -> expired.
+	feed(l, map[string]map[string]SignedData{
+		protocol.MachinesLedgerKey: {ip: mkSignedEntry(t, a, protocol.MachinesLedgerKey, ip, machine(a.ID(), ip), 1, now)},
+	})
+	// B reclaims with a higher version.
+	feed(l, map[string]map[string]SignedData{
+		protocol.MachinesLedgerKey: {ip: mkSignedEntry(t, b, protocol.MachinesLedgerKey, ip, machine(b.ID(), ip), 2, now)},
+	})
+
+	v, _ := l.GetKey(protocol.MachinesLedgerKey, ip)
+	var m map[string]string
+	v.Unmarshal(&m)
+	if m["PeerID"] != b.ID() {
+		t.Fatalf("reclaim of expired owner failed: owner = %q, want %q", m["PeerID"], b.ID())
+	}
+}
+
+func TestMergeTombstoneHidesEntry(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	l := enforcedLedger(time.Minute, now)
+	a := newTestSigner(t)
+	ip := "10.1.0.1"
+
+	feed(l, map[string]map[string]SignedData{
+		protocol.MachinesLedgerKey: {ip: mkSignedEntry(t, a, protocol.MachinesLedgerKey, ip, machine(a.ID(), ip), 1, now)},
+	})
+
+	// Signed tombstone by the owner.
+	tomb := SignedData{Owner: a.ID(), Version: 2, UpdatedAt: now.Unix(), Deleted: true}
+	tomb.Sig, _ = a.Sign(canonical(protocol.MachinesLedgerKey, ip, tomb))
+	feed(l, map[string]map[string]SignedData{protocol.MachinesLedgerKey: {ip: tomb}})
+
+	if _, found := l.GetKey(protocol.MachinesLedgerKey, ip); found {
+		t.Fatal("tombstoned entry must read as absent")
+	}
+}

--- a/pkg/blockchain/merge_test.go
+++ b/pkg/blockchain/merge_test.go
@@ -238,6 +238,20 @@ var _ = Describe("Authorized merge (enforced)", func() {
 		Expect(storedOwner(l, protocol.MachinesLedgerKey, ip)).To(Equal(a.ID()))
 	})
 
+	// DeleteBucket tombstones every key; once a bucket has no live keys it must
+	// disappear from CurrentData (matching legacy delete semantics), otherwise
+	// GetBuckets keeps listing it and AnnounceDeleteBucket never terminates.
+	It("drops a fully-tombstoned bucket from CurrentData", func() {
+		l := enforcedLedger(time.Minute, now)
+		l.SetSigner(newTestSigner())
+
+		l.Add("mybucket", map[string]interface{}{"k": "v"})
+		Expect(l.CurrentData()).To(HaveKey("mybucket"))
+
+		l.DeleteBucket("mybucket")
+		Expect(l.CurrentData()).NotTo(HaveKey("mybucket"))
+	})
+
 	It("hides a tombstoned entry", func() {
 		l := enforcedLedger(time.Minute, now)
 		a := newTestSigner()

--- a/pkg/blockchain/merge_test.go
+++ b/pkg/blockchain/merge_test.go
@@ -175,6 +175,37 @@ func TestMergeAllowsReclaimAfterOwnerExpired(t *testing.T) {
 	}
 }
 
+// DNS records carry no owner field, so the dns bucket is "self-owned": the first
+// signer to claim a name owns it, and (while it is live) no other peer may take
+// it over. This blocks hijacking an existing DNS name and enables reaping.
+func TestMergeDNSFirstClaimBlocksHijack(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	l := enforcedLedger(time.Minute, now)
+	a := newTestSigner(t)
+	b := newTestSigner(t)
+	name := "foo.internal"
+
+	feed(l, heartbeat(t, a, now)) // A is live
+	feed(l, map[string]map[string]SignedData{
+		protocol.DNSKey: {name: mkSignedEntry(t, a, protocol.DNSKey, name, map[string]string{"1": "10.0.0.5"}, 1, now)},
+	})
+	if _, found := l.GetKey(protocol.DNSKey, name); !found {
+		t.Fatal("first claim of a DNS name should be accepted")
+	}
+
+	// B tries to repoint the name with a higher version while A is live.
+	feed(l, map[string]map[string]SignedData{
+		protocol.DNSKey: {name: mkSignedEntry(t, b, protocol.DNSKey, name, map[string]string{"1": "6.6.6.6"}, 2, now)},
+	})
+
+	v, _ := l.GetKey(protocol.DNSKey, name)
+	var got map[string]string
+	v.Unmarshal(&got)
+	if got["1"] != "10.0.0.5" {
+		t.Fatalf("DNS hijack of a live owner succeeded: %v", got)
+	}
+}
+
 func TestMergeTombstoneHidesEntry(t *testing.T) {
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 	l := enforcedLedger(time.Minute, now)

--- a/pkg/blockchain/merge_test.go
+++ b/pkg/blockchain/merge_test.go
@@ -181,6 +181,63 @@ var _ = Describe("Authorized merge (enforced)", func() {
 		Expect(got["1"]).To(Equal("10.0.0.5"))
 	})
 
+	It("does not churn or warn on byte-identical re-broadcast (owned bucket)", func() {
+		warnings := 0
+		l := New(io.Discard, &MemoryStore{},
+			WithEnforcedOwnership(DefaultRegistry(time.Minute), time.Minute),
+			WithClock(func() time.Time { return now }),
+			WithViolationLogger(func(string, ...interface{}) { warnings++ }))
+		a := newTestSigner()
+		entry := mkSignedEntry(a, protocol.MachinesLedgerKey, ip, machine(a.ID(), ip), 1, now)
+
+		feed(l, map[string]map[string]SignedData{protocol.MachinesLedgerKey: {ip: entry}})
+		idx := l.LastBlock().Index
+		warnings = 0
+
+		// The Syncronizer re-broadcasts the same block every interval; that must
+		// neither mint a new block nor log a false violation.
+		feed(l, map[string]map[string]SignedData{protocol.MachinesLedgerKey: {ip: entry}})
+		Expect(l.LastBlock().Index).To(Equal(idx))
+		Expect(warnings).To(BeZero())
+	})
+
+	It("does not churn on byte-identical re-broadcast (open bucket)", func() {
+		l := enforcedLedger(time.Minute, now)
+		a := newTestSigner()
+		entry := mkSignedEntry(a, "nodes", "k", "v", 1, now)
+
+		feed(l, map[string]map[string]SignedData{"nodes": {"k": entry}})
+		idx := l.LastBlock().Index
+
+		feed(l, map[string]map[string]SignedData{"nodes": {"k": entry}})
+		Expect(l.LastBlock().Index).To(Equal(idx))
+	})
+
+	It("lets a valid owner reclaim a key cleared by a foreign tombstone", func() {
+		l := enforcedLedger(time.Minute, now)
+		a := newTestSigner()
+		reaper := newTestSigner()
+
+		// reaper is live; A is not (no heartbeat) so its entry is reapable.
+		feed(l, heartbeat(reaper, now))
+		feed(l, map[string]map[string]SignedData{
+			protocol.MachinesLedgerKey: {ip: mkSignedEntry(a, protocol.MachinesLedgerKey, ip, machine(a.ID(), ip), 1, now)},
+		})
+
+		// reaper tombstones A's entry (cross-owner allowed: A expired).
+		tomb := SignedData{Owner: reaper.ID(), Version: 2, UpdatedAt: now.Unix(), Deleted: true}
+		tomb.Sig, _ = reaper.Sign(canonical(protocol.MachinesLedgerKey, ip, tomb))
+		feed(l, map[string]map[string]SignedData{protocol.MachinesLedgerKey: {ip: tomb}})
+		_, found := l.GetKey(protocol.MachinesLedgerKey, ip)
+		Expect(found).To(BeFalse())
+
+		// A returns and reclaims its own key with a higher version.
+		feed(l, map[string]map[string]SignedData{
+			protocol.MachinesLedgerKey: {ip: mkSignedEntry(a, protocol.MachinesLedgerKey, ip, machine(a.ID(), ip), 3, now)},
+		})
+		Expect(storedOwner(l, protocol.MachinesLedgerKey, ip)).To(Equal(a.ID()))
+	})
+
 	It("hides a tombstoned entry", func() {
 		l := enforcedLedger(time.Minute, now)
 		a := newTestSigner()

--- a/pkg/blockchain/merge_test.go
+++ b/pkg/blockchain/merge_test.go
@@ -16,8 +16,10 @@ package blockchain
 import (
 	"encoding/json"
 	"io"
-	"testing"
 	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"github.com/mudler/edgevpn/pkg/hub"
 	"github.com/mudler/edgevpn/pkg/protocol"
@@ -25,14 +27,11 @@ import (
 
 // --- helpers -------------------------------------------------------------
 
-func mkSignedEntry(t *testing.T, s Signer, bucket, key string, value interface{}, version uint64, now time.Time) SignedData {
-	t.Helper()
+func mkSignedEntry(s Signer, bucket, key string, value interface{}, version uint64, now time.Time) SignedData {
 	jb, _ := json.Marshal(value)
 	d := SignedData{Value: Data(jb), Owner: s.ID(), Version: version, UpdatedAt: now.Unix()}
 	sig, err := s.Sign(canonical(bucket, key, d))
-	if err != nil {
-		t.Fatalf("sign: %v", err)
-	}
+	Expect(err).NotTo(HaveOccurred())
 	d.Sig = sig
 	return d
 }
@@ -53,10 +52,10 @@ func enforcedLedger(ttl time.Duration, now time.Time) *Ledger {
 }
 
 // heartbeat returns a signed healthcheck entry for s as of now.
-func heartbeat(t *testing.T, s Signer, now time.Time) map[string]map[string]SignedData {
+func heartbeat(s Signer, now time.Time) map[string]map[string]SignedData {
 	return map[string]map[string]SignedData{
 		protocol.HealthCheckKey: {
-			s.ID(): mkSignedEntry(t, s, protocol.HealthCheckKey, s.ID(), now.UTC().Format(time.RFC3339), 1, now),
+			s.ID(): mkSignedEntry(s, protocol.HealthCheckKey, s.ID(), now.UTC().Format(time.RFC3339), 1, now),
 		},
 	}
 }
@@ -65,163 +64,136 @@ func machine(peerID, addr string) map[string]string {
 	return map[string]string{"PeerID": peerID, "Address": addr}
 }
 
-// --- tests ---------------------------------------------------------------
-
-func TestMergeAcceptsOwnerWrite(t *testing.T) {
-	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	l := enforcedLedger(time.Minute, now)
-	a := newTestSigner(t)
-	ip := "10.1.0.1"
-
-	feed(l, map[string]map[string]SignedData{
-		protocol.MachinesLedgerKey: {ip: mkSignedEntry(t, a, protocol.MachinesLedgerKey, ip, machine(a.ID(), ip), 1, now)},
-	})
-
-	v, found := l.GetKey(protocol.MachinesLedgerKey, ip)
-	if !found {
-		t.Fatal("owner write should be accepted")
-	}
+func storedOwner(l *Ledger, bucket, key string) string {
+	v, _ := l.GetKey(bucket, key)
 	var m map[string]string
 	v.Unmarshal(&m)
-	if m["PeerID"] != a.ID() {
-		t.Fatalf("stored owner = %q, want %q", m["PeerID"], a.ID())
-	}
+	return m["PeerID"]
 }
 
-func TestMergeRejectsHijackOfLiveOwner(t *testing.T) {
+// --- specs ---------------------------------------------------------------
+
+var _ = Describe("Authorized merge (enforced)", func() {
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	l := enforcedLedger(time.Minute, now)
-	a := newTestSigner(t)
-	b := newTestSigner(t)
 	ip := "10.1.0.1"
 
-	// A is alive and owns the IP.
-	feed(l, heartbeat(t, a, now))
-	feed(l, map[string]map[string]SignedData{
-		protocol.MachinesLedgerKey: {ip: mkSignedEntry(t, a, protocol.MachinesLedgerKey, ip, machine(a.ID(), ip), 1, now)},
+	It("accepts an owner's own write", func() {
+		l := enforcedLedger(time.Minute, now)
+		a := newTestSigner()
+
+		feed(l, map[string]map[string]SignedData{
+			protocol.MachinesLedgerKey: {ip: mkSignedEntry(a, protocol.MachinesLedgerKey, ip, machine(a.ID(), ip), 1, now)},
+		})
+
+		_, found := l.GetKey(protocol.MachinesLedgerKey, ip)
+		Expect(found).To(BeTrue())
+		Expect(storedOwner(l, protocol.MachinesLedgerKey, ip)).To(Equal(a.ID()))
 	})
 
-	// B tries to steal the IP with a higher version, validly signed by B.
-	feed(l, map[string]map[string]SignedData{
-		protocol.MachinesLedgerKey: {ip: mkSignedEntry(t, b, protocol.MachinesLedgerKey, ip, machine(b.ID(), ip), 2, now)},
+	It("rejects a hijack of a live owner's entry", func() {
+		l := enforcedLedger(time.Minute, now)
+		a := newTestSigner()
+		b := newTestSigner()
+
+		// A is alive and owns the IP.
+		feed(l, heartbeat(a, now))
+		feed(l, map[string]map[string]SignedData{
+			protocol.MachinesLedgerKey: {ip: mkSignedEntry(a, protocol.MachinesLedgerKey, ip, machine(a.ID(), ip), 1, now)},
+		})
+
+		// B tries to steal the IP with a higher version, validly signed by B.
+		feed(l, map[string]map[string]SignedData{
+			protocol.MachinesLedgerKey: {ip: mkSignedEntry(b, protocol.MachinesLedgerKey, ip, machine(b.ID(), ip), 2, now)},
+		})
+
+		Expect(storedOwner(l, protocol.MachinesLedgerKey, ip)).To(Equal(a.ID()))
 	})
 
-	v, _ := l.GetKey(protocol.MachinesLedgerKey, ip)
-	var m map[string]string
-	v.Unmarshal(&m)
-	if m["PeerID"] != a.ID() {
-		t.Fatalf("hijack succeeded: owner = %q, want %q (A, who is live)", m["PeerID"], a.ID())
-	}
-}
+	It("rejects a rollback to an older version", func() {
+		l := enforcedLedger(time.Minute, now)
+		a := newTestSigner()
 
-func TestMergeRejectsRollback(t *testing.T) {
-	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	l := enforcedLedger(time.Minute, now)
-	a := newTestSigner(t)
-	ip := "10.1.0.1"
+		feed(l, map[string]map[string]SignedData{
+			protocol.MachinesLedgerKey: {ip: mkSignedEntry(a, protocol.MachinesLedgerKey, ip, machine(a.ID(), "10.9.9.9"), 2, now)},
+		})
+		feed(l, map[string]map[string]SignedData{
+			protocol.MachinesLedgerKey: {ip: mkSignedEntry(a, protocol.MachinesLedgerKey, ip, machine(a.ID(), "10.0.0.0"), 1, now)},
+		})
 
-	feed(l, map[string]map[string]SignedData{
-		protocol.MachinesLedgerKey: {ip: mkSignedEntry(t, a, protocol.MachinesLedgerKey, ip, machine(a.ID(), "10.9.9.9"), 2, now)},
-	})
-	// Replay an older version of A's own entry.
-	feed(l, map[string]map[string]SignedData{
-		protocol.MachinesLedgerKey: {ip: mkSignedEntry(t, a, protocol.MachinesLedgerKey, ip, machine(a.ID(), "10.0.0.0"), 1, now)},
+		v, _ := l.GetKey(protocol.MachinesLedgerKey, ip)
+		var m map[string]string
+		v.Unmarshal(&m)
+		Expect(m["Address"]).To(Equal("10.9.9.9"))
 	})
 
-	v, _ := l.GetKey(protocol.MachinesLedgerKey, ip)
-	var m map[string]string
-	v.Unmarshal(&m)
-	if m["Address"] != "10.9.9.9" {
-		t.Fatalf("rollback accepted: address = %q, want 10.9.9.9", m["Address"])
-	}
-}
+	It("rejects a forged signature", func() {
+		l := enforcedLedger(time.Minute, now)
+		a := newTestSigner()
 
-func TestMergeRejectsForgedSignature(t *testing.T) {
-	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	l := enforcedLedger(time.Minute, now)
-	a := newTestSigner(t)
-	ip := "10.1.0.1"
+		e := mkSignedEntry(a, protocol.MachinesLedgerKey, ip, machine(a.ID(), ip), 1, now)
+		e.Sig = []byte("garbage")
+		feed(l, map[string]map[string]SignedData{protocol.MachinesLedgerKey: {ip: e}})
 
-	e := mkSignedEntry(t, a, protocol.MachinesLedgerKey, ip, machine(a.ID(), ip), 1, now)
-	e.Sig = []byte("garbage")
-	feed(l, map[string]map[string]SignedData{protocol.MachinesLedgerKey: {ip: e}})
-
-	if _, found := l.GetKey(protocol.MachinesLedgerKey, ip); found {
-		t.Fatal("entry with forged signature must be rejected")
-	}
-}
-
-func TestMergeAllowsReclaimAfterOwnerExpired(t *testing.T) {
-	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	l := enforcedLedger(time.Minute, now)
-	a := newTestSigner(t)
-	b := newTestSigner(t)
-	ip := "10.1.0.1"
-
-	// A owns the IP but has NO heartbeat -> not live -> expired.
-	feed(l, map[string]map[string]SignedData{
-		protocol.MachinesLedgerKey: {ip: mkSignedEntry(t, a, protocol.MachinesLedgerKey, ip, machine(a.ID(), ip), 1, now)},
-	})
-	// B reclaims with a higher version.
-	feed(l, map[string]map[string]SignedData{
-		protocol.MachinesLedgerKey: {ip: mkSignedEntry(t, b, protocol.MachinesLedgerKey, ip, machine(b.ID(), ip), 2, now)},
+		_, found := l.GetKey(protocol.MachinesLedgerKey, ip)
+		Expect(found).To(BeFalse())
 	})
 
-	v, _ := l.GetKey(protocol.MachinesLedgerKey, ip)
-	var m map[string]string
-	v.Unmarshal(&m)
-	if m["PeerID"] != b.ID() {
-		t.Fatalf("reclaim of expired owner failed: owner = %q, want %q", m["PeerID"], b.ID())
-	}
-}
+	It("allows reclaim once the owner has expired", func() {
+		l := enforcedLedger(time.Minute, now)
+		a := newTestSigner()
+		b := newTestSigner()
 
-// DNS records carry no owner field, so the dns bucket is "self-owned": the first
-// signer to claim a name owns it, and (while it is live) no other peer may take
-// it over. This blocks hijacking an existing DNS name and enables reaping.
-func TestMergeDNSFirstClaimBlocksHijack(t *testing.T) {
-	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	l := enforcedLedger(time.Minute, now)
-	a := newTestSigner(t)
-	b := newTestSigner(t)
-	name := "foo.internal"
+		// A owns the IP but has NO heartbeat -> not live -> expired.
+		feed(l, map[string]map[string]SignedData{
+			protocol.MachinesLedgerKey: {ip: mkSignedEntry(a, protocol.MachinesLedgerKey, ip, machine(a.ID(), ip), 1, now)},
+		})
+		// B reclaims with a higher version.
+		feed(l, map[string]map[string]SignedData{
+			protocol.MachinesLedgerKey: {ip: mkSignedEntry(b, protocol.MachinesLedgerKey, ip, machine(b.ID(), ip), 2, now)},
+		})
 
-	feed(l, heartbeat(t, a, now)) // A is live
-	feed(l, map[string]map[string]SignedData{
-		protocol.DNSKey: {name: mkSignedEntry(t, a, protocol.DNSKey, name, map[string]string{"1": "10.0.0.5"}, 1, now)},
-	})
-	if _, found := l.GetKey(protocol.DNSKey, name); !found {
-		t.Fatal("first claim of a DNS name should be accepted")
-	}
-
-	// B tries to repoint the name with a higher version while A is live.
-	feed(l, map[string]map[string]SignedData{
-		protocol.DNSKey: {name: mkSignedEntry(t, b, protocol.DNSKey, name, map[string]string{"1": "6.6.6.6"}, 2, now)},
+		Expect(storedOwner(l, protocol.MachinesLedgerKey, ip)).To(Equal(b.ID()))
 	})
 
-	v, _ := l.GetKey(protocol.DNSKey, name)
-	var got map[string]string
-	v.Unmarshal(&got)
-	if got["1"] != "10.0.0.5" {
-		t.Fatalf("DNS hijack of a live owner succeeded: %v", got)
-	}
-}
+	// DNS records carry no owner field, so the dns bucket is "self-owned": the
+	// first signer to claim a name owns it, and while it is live no other peer
+	// may take it over.
+	It("blocks DNS hijack via first-claim", func() {
+		l := enforcedLedger(time.Minute, now)
+		a := newTestSigner()
+		b := newTestSigner()
+		name := "foo.internal"
 
-func TestMergeTombstoneHidesEntry(t *testing.T) {
-	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	l := enforcedLedger(time.Minute, now)
-	a := newTestSigner(t)
-	ip := "10.1.0.1"
+		feed(l, heartbeat(a, now)) // A is live
+		feed(l, map[string]map[string]SignedData{
+			protocol.DNSKey: {name: mkSignedEntry(a, protocol.DNSKey, name, map[string]string{"1": "10.0.0.5"}, 1, now)},
+		})
+		_, found := l.GetKey(protocol.DNSKey, name)
+		Expect(found).To(BeTrue())
 
-	feed(l, map[string]map[string]SignedData{
-		protocol.MachinesLedgerKey: {ip: mkSignedEntry(t, a, protocol.MachinesLedgerKey, ip, machine(a.ID(), ip), 1, now)},
+		feed(l, map[string]map[string]SignedData{
+			protocol.DNSKey: {name: mkSignedEntry(b, protocol.DNSKey, name, map[string]string{"1": "6.6.6.6"}, 2, now)},
+		})
+
+		v, _ := l.GetKey(protocol.DNSKey, name)
+		var got map[string]string
+		v.Unmarshal(&got)
+		Expect(got["1"]).To(Equal("10.0.0.5"))
 	})
 
-	// Signed tombstone by the owner.
-	tomb := SignedData{Owner: a.ID(), Version: 2, UpdatedAt: now.Unix(), Deleted: true}
-	tomb.Sig, _ = a.Sign(canonical(protocol.MachinesLedgerKey, ip, tomb))
-	feed(l, map[string]map[string]SignedData{protocol.MachinesLedgerKey: {ip: tomb}})
+	It("hides a tombstoned entry", func() {
+		l := enforcedLedger(time.Minute, now)
+		a := newTestSigner()
 
-	if _, found := l.GetKey(protocol.MachinesLedgerKey, ip); found {
-		t.Fatal("tombstoned entry must read as absent")
-	}
-}
+		feed(l, map[string]map[string]SignedData{
+			protocol.MachinesLedgerKey: {ip: mkSignedEntry(a, protocol.MachinesLedgerKey, ip, machine(a.ID(), ip), 1, now)},
+		})
+
+		tomb := SignedData{Owner: a.ID(), Version: 2, UpdatedAt: now.Unix(), Deleted: true}
+		tomb.Sig, _ = a.Sign(canonical(protocol.MachinesLedgerKey, ip, tomb))
+		feed(l, map[string]map[string]SignedData{protocol.MachinesLedgerKey: {ip: tomb}})
+
+		_, found := l.GetKey(protocol.MachinesLedgerKey, ip)
+		Expect(found).To(BeFalse())
+	})
+})

--- a/pkg/blockchain/policy.go
+++ b/pkg/blockchain/policy.go
@@ -72,10 +72,12 @@ func DefaultRegistry(ttl time.Duration) Registry {
 		protocol.FilesLedgerKey:    {Owned: true, OwnerOf: ownerFromPeerIDField, Expiry: Liveness, Reclaimable: true},
 		protocol.UsersLedgerKey:    {Owned: true, OwnerOf: ownerIsKey, Expiry: Liveness},
 		protocol.HealthCheckKey:    {Owned: true, OwnerOf: ownerIsKey, Expiry: Absolute, TTL: ttl},
-		// NOTE: the dns bucket is intentionally left open for now. Its value
-		// type (types.DNS) carries no owner, so "first-claim + lease" ownership
-		// needs an owner field on the record plus the dns service stamping it.
-		// Tracked as a follow-up; see docs/design/authenticated-ledger.md.
+		// dns is self-owned: the value (types.DNS) carries no owner field, so a
+		// nil OwnerOf means the first signer to claim a name owns it (first-claim
+		// + lease). This blocks hijacking an existing name; constraining which
+		// names/targets a peer may register (e.g. rejecting ".*" catch-alls) is
+		// further hardening tracked separately.
+		protocol.DNSKey: {Owned: true, OwnerOf: nil, Expiry: Liveness, Reclaimable: true},
 	}
 }
 

--- a/pkg/blockchain/policy.go
+++ b/pkg/blockchain/policy.go
@@ -1,0 +1,99 @@
+/*
+Copyright © 2021-2022 Ettore Di Giacinto <mudler@mocaccino.org>
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blockchain
+
+import (
+	"time"
+
+	"github.com/mudler/edgevpn/pkg/protocol"
+)
+
+// ExpiryKind selects how a bucket's entries are aged out. See
+// docs/design/authenticated-ledger.md.
+type ExpiryKind int
+
+const (
+	// NoExpiry: entries live forever (default for unregistered/legacy buckets).
+	NoExpiry ExpiryKind = iota
+	// Liveness: an entry is alive iff its owner's heartbeat is fresh.
+	Liveness
+	// Absolute: an entry expires TTL after its own signed UpdatedAt.
+	Absolute
+)
+
+// BucketPolicy is the single source of truth for whether a bucket is
+// authenticated and how its entries expire. Adding a new authenticated bucket
+// is a one-line registry entry.
+type BucketPolicy struct {
+	Owned       bool                            // signed + owner-enforced?
+	OwnerOf     func(key string, v Data) string // who owns this entry
+	Expiry      ExpiryKind
+	TTL         time.Duration // only meaningful for Absolute
+	Reclaimable bool          // may a non-owner claim the key after expiry?
+}
+
+// Registry maps bucket name -> policy. The zero BucketPolicy (returned for any
+// unregistered bucket) is unowned/open and never expires, preserving legacy
+// behaviour for buckets we have not opted in.
+type Registry map[string]BucketPolicy
+
+// Policy returns the policy for a bucket, or the open/legacy zero value.
+func (r Registry) Policy(bucket string) BucketPolicy { return r[bucket] }
+
+// ownerIsKey is the OwnerOf for buckets where the key itself is the owner
+// peer.ID (users, healthcheck).
+func ownerIsKey(key string, _ Data) string { return key }
+
+// ownerFromPeerIDField is the OwnerOf for buckets whose value carries a PeerID
+// field (machines, services, files, dns).
+func ownerFromPeerIDField(_ string, v Data) string {
+	var s struct{ PeerID string }
+	_ = v.Unmarshal(&s)
+	return s.PeerID
+}
+
+// DefaultRegistry is the built-in policy set. ttl is the liveness window
+// (reused as the Absolute TTL for the heartbeat bucket itself).
+func DefaultRegistry(ttl time.Duration) Registry {
+	return Registry{
+		protocol.MachinesLedgerKey: {Owned: true, OwnerOf: ownerFromPeerIDField, Expiry: Liveness, Reclaimable: true},
+		protocol.ServicesLedgerKey: {Owned: true, OwnerOf: ownerFromPeerIDField, Expiry: Liveness, Reclaimable: true},
+		protocol.FilesLedgerKey:    {Owned: true, OwnerOf: ownerFromPeerIDField, Expiry: Liveness, Reclaimable: true},
+		protocol.UsersLedgerKey:    {Owned: true, OwnerOf: ownerIsKey, Expiry: Liveness},
+		protocol.HealthCheckKey:    {Owned: true, OwnerOf: ownerIsKey, Expiry: Absolute, TTL: ttl},
+		// NOTE: the dns bucket is intentionally left open for now. Its value
+		// type (types.DNS) carries no owner, so "first-claim + lease" ownership
+		// needs an owner field on the record plus the dns service stamping it.
+		// Tracked as a follow-up; see docs/design/authenticated-ledger.md.
+	}
+}
+
+// IsLive reports whether owner has a heartbeat in healthData (a map of
+// peer.ID -> RFC3339 timestamp, as written by the alive service) that is newer
+// than ttl relative to now.
+func IsLive(healthData map[string]Data, owner string, ttl time.Duration, now time.Time) bool {
+	t, ok := healthData[owner]
+	if !ok {
+		return false
+	}
+	var s string
+	if err := t.Unmarshal(&s); err != nil {
+		return false
+	}
+	parsed, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		return false
+	}
+	return parsed.Add(ttl).After(now)
+}

--- a/pkg/blockchain/policy.go
+++ b/pkg/blockchain/policy.go
@@ -78,6 +78,16 @@ func DefaultRegistry(ttl time.Duration) Registry {
 		// names/targets a peer may register (e.g. rejecting ".*" catch-alls) is
 		// further hardening tracked separately.
 		protocol.DNSKey: {Owned: true, OwnerOf: nil, Expiry: Liveness, Reclaimable: true},
+		// egress advertises a node as an HTTP egress; the key is the peer.ID, so
+		// the owner is the key. Signing it stops a peer from forging egress
+		// entries for others (which would let it intercept proxied traffic).
+		protocol.EgressService: {Owned: true, OwnerOf: ownerIsKey, Expiry: Liveness},
+		// NOTE: the "dhcp" bucket (IP-lease leader election) is intentionally left
+		// open. Its single shared "leader" key changes owner as leadership hands
+		// off, so self-owning it would stall handoff for a TTL; and the reader
+		// already cross-checks the recorded leader against the deterministic
+		// utils.Leader election, bounding a forged value to a self-correcting
+		// stall (no IP hijack — the machines bucket that assigns IPs is signed).
 	}
 }
 

--- a/pkg/blockchain/policy_test.go
+++ b/pkg/blockchain/policy_test.go
@@ -15,8 +15,10 @@ package blockchain
 
 import (
 	"encoding/json"
-	"testing"
 	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"github.com/mudler/edgevpn/pkg/protocol"
 )
@@ -26,37 +28,38 @@ func tsData(t time.Time) Data {
 	return Data(b)
 }
 
-func TestIsLive(t *testing.T) {
+var _ = Describe("Policy & liveness", func() {
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	hd := map[string]Data{
-		"peerA": tsData(now.Add(-10 * time.Second)),
-		"peerB": tsData(now.Add(-10 * time.Minute)),
-	}
 
-	if !IsLive(hd, "peerA", time.Minute, now) {
-		t.Fatal("peerA heartbeat is recent, should be live")
-	}
-	if IsLive(hd, "peerB", time.Minute, now) {
-		t.Fatal("peerB heartbeat is stale, should not be live")
-	}
-	if IsLive(hd, "unknown", time.Minute, now) {
-		t.Fatal("peer with no heartbeat should not be live")
-	}
-}
+	Describe("IsLive", func() {
+		hd := map[string]Data{
+			"peerA": tsData(now.Add(-10 * time.Second)),
+			"peerB": tsData(now.Add(-10 * time.Minute)),
+		}
 
-func TestDefaultRegistryOwnership(t *testing.T) {
-	r := DefaultRegistry(time.Minute)
+		It("reports a peer with a recent heartbeat as live", func() {
+			Expect(IsLive(hd, "peerA", time.Minute, now)).To(BeTrue())
+		})
+		It("reports a peer with a stale heartbeat as not live", func() {
+			Expect(IsLive(hd, "peerB", time.Minute, now)).To(BeFalse())
+		})
+		It("reports a peer with no heartbeat as not live", func() {
+			Expect(IsLive(hd, "unknown", time.Minute, now)).To(BeFalse())
+		})
+	})
 
-	machine, _ := json.Marshal(map[string]string{"PeerID": "peerX", "Address": "10.1.0.1"})
-	if got := r.Policy(protocol.MachinesLedgerKey).OwnerOf("10.1.0.1", Data(machine)); got != "peerX" {
-		t.Fatalf("machine owner = %q, want peerX", got)
-	}
+	Describe("DefaultRegistry ownership", func() {
+		r := DefaultRegistry(time.Minute)
 
-	if got := r.Policy(protocol.UsersLedgerKey).OwnerOf("peerY", ""); got != "peerY" {
-		t.Fatalf("user owner = %q, want peerY (key is owner)", got)
-	}
-
-	if r.Policy("some-unregistered-bucket").Owned {
-		t.Fatal("unregistered bucket must be unowned (open) by default")
-	}
-}
+		It("derives the machine owner from the PeerID field", func() {
+			machine, _ := json.Marshal(map[string]string{"PeerID": "peerX", "Address": "10.1.0.1"})
+			Expect(r.Policy(protocol.MachinesLedgerKey).OwnerOf("10.1.0.1", Data(machine))).To(Equal("peerX"))
+		})
+		It("treats the key as the owner for the users bucket", func() {
+			Expect(r.Policy(protocol.UsersLedgerKey).OwnerOf("peerY", "")).To(Equal("peerY"))
+		})
+		It("leaves unregistered buckets unowned (open)", func() {
+			Expect(r.Policy("some-unregistered-bucket").Owned).To(BeFalse())
+		})
+	})
+})

--- a/pkg/blockchain/policy_test.go
+++ b/pkg/blockchain/policy_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright © 2021-2022 Ettore Di Giacinto <mudler@mocaccino.org>
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blockchain
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/mudler/edgevpn/pkg/protocol"
+)
+
+func tsData(t time.Time) Data {
+	b, _ := json.Marshal(t.UTC().Format(time.RFC3339))
+	return Data(b)
+}
+
+func TestIsLive(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	hd := map[string]Data{
+		"peerA": tsData(now.Add(-10 * time.Second)),
+		"peerB": tsData(now.Add(-10 * time.Minute)),
+	}
+
+	if !IsLive(hd, "peerA", time.Minute, now) {
+		t.Fatal("peerA heartbeat is recent, should be live")
+	}
+	if IsLive(hd, "peerB", time.Minute, now) {
+		t.Fatal("peerB heartbeat is stale, should not be live")
+	}
+	if IsLive(hd, "unknown", time.Minute, now) {
+		t.Fatal("peer with no heartbeat should not be live")
+	}
+}
+
+func TestDefaultRegistryOwnership(t *testing.T) {
+	r := DefaultRegistry(time.Minute)
+
+	machine, _ := json.Marshal(map[string]string{"PeerID": "peerX", "Address": "10.1.0.1"})
+	if got := r.Policy(protocol.MachinesLedgerKey).OwnerOf("10.1.0.1", Data(machine)); got != "peerX" {
+		t.Fatalf("machine owner = %q, want peerX", got)
+	}
+
+	if got := r.Policy(protocol.UsersLedgerKey).OwnerOf("peerY", ""); got != "peerY" {
+		t.Fatalf("user owner = %q, want peerY (key is owner)", got)
+	}
+
+	if r.Policy("some-unregistered-bucket").Owned {
+		t.Fatal("unregistered bucket must be unowned (open) by default")
+	}
+}

--- a/pkg/blockchain/reaper.go
+++ b/pkg/blockchain/reaper.go
@@ -27,46 +27,39 @@ import (
 //
 // See docs/design/authenticated-ledger.md (section 9).
 func (l *Ledger) Reap(tombstoneTTL time.Duration) {
-	l.Lock()
-	if l.mode == OwnershipOff || l.signer == nil {
-		l.Unlock()
-		return
-	}
-	cur := copyStorage(l.blockchain.Last().Storage)
-	registry := l.registry
-	now := l.clock()
-	l.Unlock()
+	l.commit(true, func(cur map[string]map[string]SignedData) bool {
+		if l.mode == OwnershipOff || l.signer == nil {
+			return false
+		}
+		now := l.clock()
+		health := projectValues(cur[protocol.HealthCheckKey])
+		changed := false
 
-	health := projectValues(cur[protocol.HealthCheckKey])
-	changed := false
+		for bucket, kv := range cur {
+			pol := l.registry.Policy(bucket)
+			for key, e := range kv {
+				// Prune tombstones that everyone has had time to observe.
+				if e.Deleted {
+					if time.Unix(e.UpdatedAt, 0).Add(tombstoneTTL).Before(now) {
+						delete(cur[bucket], key)
+						changed = true
+					}
+					continue
+				}
 
-	for bucket, kv := range cur {
-		pol := registry.Policy(bucket)
-		for key, e := range kv {
-			// Prune tombstones that everyone has had time to observe.
-			if e.Deleted {
-				if time.Unix(e.UpdatedAt, 0).Add(tombstoneTTL).Before(now) {
-					delete(cur[bucket], key)
+				if !pol.Owned || pol.Expiry == NoExpiry {
+					continue
+				}
+				// Tombstone any entry past its lease (inactive Liveness owner, or
+				// Absolute-expired such as a stale heartbeat).
+				if l.expired(bucket, key, e, pol, health, now) {
+					cur[bucket][key] = l.makeTombstone(bucket, key, e, now)
 					changed = true
 				}
-				continue
-			}
-
-			if !pol.Owned || pol.Expiry == NoExpiry {
-				continue
-			}
-			// Tombstone any entry past its lease (inactive Liveness owner, or
-			// Absolute-expired such as a stale heartbeat).
-			if l.expired(bucket, key, e, pol, health, now) {
-				cur[bucket][key] = l.makeTombstone(bucket, key, e, now)
-				changed = true
 			}
 		}
-	}
-
-	if changed {
-		l.writeData(cur)
-	}
+		return changed
+	})
 }
 
 // LivenessBuckets returns the buckets whose entries expire with owner liveness.

--- a/pkg/blockchain/reaper.go
+++ b/pkg/blockchain/reaper.go
@@ -89,3 +89,20 @@ func (l *Ledger) OwnershipEnabled() bool {
 	defer l.Unlock()
 	return l.mode != OwnershipOff
 }
+
+// IsOwnerLive reports whether owner currently has a fresh heartbeat. When
+// ownership is disabled it always returns true, so existing readers behave
+// exactly as before; under observe/enforce it lets readers skip entries whose
+// owner has gone inactive without waiting for the reaper to tombstone them.
+func (l *Ledger) IsOwnerLive(owner string) bool {
+	l.Lock()
+	if l.mode == OwnershipOff {
+		l.Unlock()
+		return true
+	}
+	health := projectValues(l.blockchain.Last().Storage[protocol.HealthCheckKey])
+	ttl := l.ttl
+	now := l.clock()
+	l.Unlock()
+	return IsLive(health, owner, ttl, now)
+}

--- a/pkg/blockchain/reaper.go
+++ b/pkg/blockchain/reaper.go
@@ -1,0 +1,91 @@
+/*
+Copyright © 2021-2022 Ettore Di Giacinto <mudler@mocaccino.org>
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blockchain
+
+import (
+	"time"
+
+	"github.com/mudler/edgevpn/pkg/protocol"
+)
+
+// Reap bounds ledger growth from inactive nodes. For every Liveness-managed
+// bucket it signs a tombstone over each entry whose owner is no longer live,
+// and it physically prunes tombstones older than tombstoneTTL. It is a no-op
+// unless ownership is enabled and a signer is set; callers should run it only
+// on the elected leader to avoid redundant writes.
+//
+// See docs/design/authenticated-ledger.md (section 9).
+func (l *Ledger) Reap(tombstoneTTL time.Duration) {
+	l.Lock()
+	if l.mode == OwnershipOff || l.signer == nil {
+		l.Unlock()
+		return
+	}
+	cur := copyStorage(l.blockchain.Last().Storage)
+	registry := l.registry
+	now := l.clock()
+	l.Unlock()
+
+	health := projectValues(cur[protocol.HealthCheckKey])
+	changed := false
+
+	for bucket, kv := range cur {
+		pol := registry.Policy(bucket)
+		for key, e := range kv {
+			// Prune tombstones that everyone has had time to observe.
+			if e.Deleted {
+				if time.Unix(e.UpdatedAt, 0).Add(tombstoneTTL).Before(now) {
+					delete(cur[bucket], key)
+					changed = true
+				}
+				continue
+			}
+
+			if !pol.Owned || pol.Expiry == NoExpiry {
+				continue
+			}
+			// Tombstone any entry past its lease (inactive Liveness owner, or
+			// Absolute-expired such as a stale heartbeat).
+			if l.expired(bucket, key, e, pol, health, now) {
+				cur[bucket][key] = l.makeTombstone(bucket, key, e, now)
+				changed = true
+			}
+		}
+	}
+
+	if changed {
+		l.writeData(cur)
+	}
+}
+
+// LivenessBuckets returns the buckets whose entries expire with owner liveness.
+func (l *Ledger) LivenessBuckets() []string {
+	l.Lock()
+	defer l.Unlock()
+	var out []string
+	for name, pol := range l.registry {
+		if pol.Expiry == Liveness {
+			out = append(out, name)
+		}
+	}
+	return out
+}
+
+// OwnershipEnabled reports whether the ledger is running the authenticated
+// merge (observe or enforce).
+func (l *Ledger) OwnershipEnabled() bool {
+	l.Lock()
+	defer l.Unlock()
+	return l.mode != OwnershipOff
+}

--- a/pkg/blockchain/reaper_test.go
+++ b/pkg/blockchain/reaper_test.go
@@ -15,75 +15,69 @@ package blockchain
 
 import (
 	"io"
-	"testing"
 	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"github.com/mudler/edgevpn/pkg/protocol"
 )
 
-func TestIsOwnerLive(t *testing.T) {
+var _ = Describe("Reaper", func() {
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
 
-	// With ownership disabled, liveness is not tracked: everyone is "live" so
-	// readers keep their current behaviour.
-	off := New(io.Discard, &MemoryStore{})
-	if !off.IsOwnerLive("anyone") {
-		t.Fatal("ownership off should treat any owner as live")
-	}
+	It("tombstones entries of inactive owners and keeps live ones", func() {
+		l := enforcedLedger(time.Minute, now)
+		a := newTestSigner()
+		b := newTestSigner()
 
-	l := enforcedLedger(time.Minute, now)
-	a := newTestSigner(t)
-	feed(l, heartbeat(t, a, now))
+		// A is live and owns ip1; B has no heartbeat and owns ip2.
+		feed(l, heartbeat(a, now))
+		feed(l, map[string]map[string]SignedData{
+			protocol.MachinesLedgerKey: {
+				"10.1.0.1": mkSignedEntry(a, protocol.MachinesLedgerKey, "10.1.0.1", machine(a.ID(), "10.1.0.1"), 1, now),
+				"10.1.0.2": mkSignedEntry(b, protocol.MachinesLedgerKey, "10.1.0.2", machine(b.ID(), "10.1.0.2"), 1, now),
+			},
+		})
 
-	if !l.IsOwnerLive(a.ID()) {
-		t.Fatal("owner with a fresh heartbeat should be live")
-	}
-	if l.IsOwnerLive("ghost") {
-		t.Fatal("owner with no heartbeat should not be live")
-	}
-}
+		// Reaping happens by an authorized signer.
+		l.SetSigner(a)
+		l.Reap(time.Hour)
 
-func TestReapTombstonesInactiveOwners(t *testing.T) {
-	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	l := enforcedLedger(time.Minute, now)
-	a := newTestSigner(t)
-	b := newTestSigner(t)
-
-	// A is live and owns ip1; B has no heartbeat and owns ip2.
-	feed(l, heartbeat(t, a, now))
-	feed(l, map[string]map[string]SignedData{
-		protocol.MachinesLedgerKey: {
-			"10.1.0.1": mkSignedEntry(t, a, protocol.MachinesLedgerKey, "10.1.0.1", machine(a.ID(), "10.1.0.1"), 1, now),
-			"10.1.0.2": mkSignedEntry(t, b, protocol.MachinesLedgerKey, "10.1.0.2", machine(b.ID(), "10.1.0.2"), 1, now),
-		},
+		_, foundB := l.GetKey(protocol.MachinesLedgerKey, "10.1.0.2")
+		Expect(foundB).To(BeFalse(), "entry of inactive owner B should be tombstoned")
+		_, foundA := l.GetKey(protocol.MachinesLedgerKey, "10.1.0.1")
+		Expect(foundA).To(BeTrue(), "entry of live owner A must be kept")
 	})
 
-	// Reaping must happen by an authorized signer; give the ledger A's key.
-	l.SetSigner(a)
-	l.Reap(time.Hour)
+	It("prunes tombstones older than the tombstone TTL", func() {
+		l := enforcedLedger(time.Minute, now)
+		a := newTestSigner()
+		l.SetSigner(a)
 
-	if _, found := l.GetKey(protocol.MachinesLedgerKey, "10.1.0.2"); found {
-		t.Fatal("entry of inactive owner B should be tombstoned")
-	}
-	if _, found := l.GetKey(protocol.MachinesLedgerKey, "10.1.0.1"); !found {
-		t.Fatal("entry of live owner A must be kept")
-	}
-}
+		old := SignedData{Owner: a.ID(), Version: 5, UpdatedAt: now.Add(-2 * time.Hour).Unix(), Deleted: true}
+		old.Sig, _ = a.Sign(canonical(protocol.MachinesLedgerKey, "10.1.0.9", old))
+		feed(l, map[string]map[string]SignedData{protocol.MachinesLedgerKey: {"10.1.0.9": old}})
 
-func TestReapPrunesOldTombstones(t *testing.T) {
-	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	l := enforcedLedger(time.Minute, now)
-	a := newTestSigner(t)
-	l.SetSigner(a)
+		l.Reap(time.Hour) // tombstone-ttl = 1h, this one is 2h old
 
-	// An old tombstone (UpdatedAt well in the past) for a machines key.
-	old := SignedData{Owner: a.ID(), Version: 5, UpdatedAt: now.Add(-2 * time.Hour).Unix(), Deleted: true}
-	old.Sig, _ = a.Sign(canonical(protocol.MachinesLedgerKey, "10.1.0.9", old))
-	feed(l, map[string]map[string]SignedData{protocol.MachinesLedgerKey: {"10.1.0.9": old}})
+		_, ok := l.CurrentStorage()[protocol.MachinesLedgerKey]["10.1.0.9"]
+		Expect(ok).To(BeFalse(), "tombstone older than the tombstone-ttl must be pruned")
+	})
 
-	l.Reap(time.Hour) // tombstone-ttl = 1h, this one is 2h old
+	Describe("IsOwnerLive", func() {
+		It("treats every owner as live when ownership is disabled", func() {
+			off := New(io.Discard, &MemoryStore{})
+			Expect(off.IsOwnerLive("anyone")).To(BeTrue())
+		})
 
-	if _, ok := l.CurrentStorage()[protocol.MachinesLedgerKey]["10.1.0.9"]; ok {
-		t.Fatal("tombstone older than the tombstone-ttl must be physically pruned")
-	}
-}
+		It("reflects heartbeat freshness under enforcement", func() {
+			l := enforcedLedger(time.Minute, now)
+			a := newTestSigner()
+			feed(l, heartbeat(a, now))
+
+			Expect(l.IsOwnerLive(a.ID())).To(BeTrue())
+			Expect(l.IsOwnerLive("ghost")).To(BeFalse())
+		})
+	})
+})

--- a/pkg/blockchain/reaper_test.go
+++ b/pkg/blockchain/reaper_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright © 2021-2022 Ettore Di Giacinto <mudler@mocaccino.org>
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blockchain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/mudler/edgevpn/pkg/protocol"
+)
+
+func TestReapTombstonesInactiveOwners(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	l := enforcedLedger(time.Minute, now)
+	a := newTestSigner(t)
+	b := newTestSigner(t)
+
+	// A is live and owns ip1; B has no heartbeat and owns ip2.
+	feed(l, heartbeat(t, a, now))
+	feed(l, map[string]map[string]SignedData{
+		protocol.MachinesLedgerKey: {
+			"10.1.0.1": mkSignedEntry(t, a, protocol.MachinesLedgerKey, "10.1.0.1", machine(a.ID(), "10.1.0.1"), 1, now),
+			"10.1.0.2": mkSignedEntry(t, b, protocol.MachinesLedgerKey, "10.1.0.2", machine(b.ID(), "10.1.0.2"), 1, now),
+		},
+	})
+
+	// Reaping must happen by an authorized signer; give the ledger A's key.
+	l.SetSigner(a)
+	l.Reap(time.Hour)
+
+	if _, found := l.GetKey(protocol.MachinesLedgerKey, "10.1.0.2"); found {
+		t.Fatal("entry of inactive owner B should be tombstoned")
+	}
+	if _, found := l.GetKey(protocol.MachinesLedgerKey, "10.1.0.1"); !found {
+		t.Fatal("entry of live owner A must be kept")
+	}
+}
+
+func TestReapPrunesOldTombstones(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	l := enforcedLedger(time.Minute, now)
+	a := newTestSigner(t)
+	l.SetSigner(a)
+
+	// An old tombstone (UpdatedAt well in the past) for a machines key.
+	old := SignedData{Owner: a.ID(), Version: 5, UpdatedAt: now.Add(-2 * time.Hour).Unix(), Deleted: true}
+	old.Sig, _ = a.Sign(canonical(protocol.MachinesLedgerKey, "10.1.0.9", old))
+	feed(l, map[string]map[string]SignedData{protocol.MachinesLedgerKey: {"10.1.0.9": old}})
+
+	l.Reap(time.Hour) // tombstone-ttl = 1h, this one is 2h old
+
+	if _, ok := l.CurrentStorage()[protocol.MachinesLedgerKey]["10.1.0.9"]; ok {
+		t.Fatal("tombstone older than the tombstone-ttl must be physically pruned")
+	}
+}

--- a/pkg/blockchain/reaper_test.go
+++ b/pkg/blockchain/reaper_test.go
@@ -14,11 +14,34 @@ limitations under the License.
 package blockchain
 
 import (
+	"io"
 	"testing"
 	"time"
 
 	"github.com/mudler/edgevpn/pkg/protocol"
 )
+
+func TestIsOwnerLive(t *testing.T) {
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	// With ownership disabled, liveness is not tracked: everyone is "live" so
+	// readers keep their current behaviour.
+	off := New(io.Discard, &MemoryStore{})
+	if !off.IsOwnerLive("anyone") {
+		t.Fatal("ownership off should treat any owner as live")
+	}
+
+	l := enforcedLedger(time.Minute, now)
+	a := newTestSigner(t)
+	feed(l, heartbeat(t, a, now))
+
+	if !l.IsOwnerLive(a.ID()) {
+		t.Fatal("owner with a fresh heartbeat should be live")
+	}
+	if l.IsOwnerLive("ghost") {
+		t.Fatal("owner with no heartbeat should not be live")
+	}
+}
 
 func TestReapTombstonesInactiveOwners(t *testing.T) {
 	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)

--- a/pkg/blockchain/sign.go
+++ b/pkg/blockchain/sign.go
@@ -1,0 +1,107 @@
+/*
+Copyright © 2021-2022 Ettore Di Giacinto <mudler@mocaccino.org>
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blockchain
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/libp2p/go-libp2p/core/crypto"
+	"github.com/libp2p/go-libp2p/core/peer"
+)
+
+// Signer authenticates ledger writes. In production it wraps the libp2p host
+// identity key; in tests it can wrap any generated key.
+type Signer interface {
+	Sign(msg []byte) ([]byte, error)
+	ID() string // base58 peer.ID of the signer
+}
+
+type keySigner struct {
+	priv crypto.PrivKey
+	id   string
+}
+
+// NewSigner builds a Signer from a libp2p private key, deriving the peer ID
+// that owners are matched against.
+func NewSigner(priv crypto.PrivKey) (Signer, error) {
+	id, err := peer.IDFromPublicKey(priv.GetPublic())
+	if err != nil {
+		return nil, err
+	}
+	return &keySigner{priv: priv, id: id.String()}, nil
+}
+
+func (s *keySigner) Sign(msg []byte) ([]byte, error) { return s.priv.Sign(msg) }
+func (s *keySigner) ID() string                      { return s.id }
+
+// canonical produces the deterministic byte string that is signed/verified for
+// an entry. Every field that must be tamper-evident is length-prefixed so the
+// encoding is unambiguous and identical on every node (never rely on Go map or
+// fmt ordering here).
+func canonical(bucket, key string, d SignedData) []byte {
+	buf := &bytes.Buffer{}
+	writeField(buf, []byte(bucket))
+	writeField(buf, []byte(key))
+	writeField(buf, []byte(d.Owner))
+
+	var u8 [8]byte
+	binary.BigEndian.PutUint64(u8[:], d.Version)
+	buf.Write(u8[:])
+	binary.BigEndian.PutUint64(u8[:], uint64(d.UpdatedAt))
+	buf.Write(u8[:])
+
+	if d.Deleted {
+		buf.WriteByte(1)
+	} else {
+		buf.WriteByte(0)
+	}
+
+	writeField(buf, []byte(d.Value))
+	return buf.Bytes()
+}
+
+func writeField(buf *bytes.Buffer, b []byte) {
+	var l [8]byte
+	binary.BigEndian.PutUint64(l[:], uint64(len(b)))
+	buf.Write(l[:])
+	buf.Write(b)
+}
+
+// Verify checks that an entry was signed by the peer it claims as Owner. The
+// verifying public key is recovered directly from the Owner peer.ID (libp2p
+// Ed25519 identities embed it), so no key distribution is needed.
+func Verify(bucket, key string, d SignedData) error {
+	pid, err := peer.Decode(d.Owner)
+	if err != nil {
+		return fmt.Errorf("invalid owner id %q: %w", d.Owner, err)
+	}
+	pub, err := pid.ExtractPublicKey()
+	if err != nil {
+		return fmt.Errorf("cannot extract public key from owner id %q: %w", d.Owner, err)
+	}
+	if pub == nil {
+		return errors.New("owner id has no embedded public key")
+	}
+	ok, err := pub.Verify(canonical(bucket, key, d), d.Sig)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return errors.New("signature verification failed")
+	}
+	return nil
+}

--- a/pkg/blockchain/sign_test.go
+++ b/pkg/blockchain/sign_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright © 2021-2022 Ettore Di Giacinto <mudler@mocaccino.org>
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package blockchain
+
+import (
+	"testing"
+
+	"github.com/libp2p/go-libp2p/core/crypto"
+)
+
+func newTestSigner(t *testing.T) Signer {
+	t.Helper()
+	priv, _, err := crypto.GenerateKeyPair(crypto.Ed25519, 0)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	s, err := NewSigner(priv)
+	if err != nil {
+		t.Fatalf("new signer: %v", err)
+	}
+	return s
+}
+
+func TestSignVerifyRoundTrip(t *testing.T) {
+	s := newTestSigner(t)
+	d := SignedData{Value: "hello", Owner: s.ID(), Version: 1, UpdatedAt: 100}
+
+	sig, err := s.Sign(canonical("machines", "10.1.0.1", d))
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+	d.Sig = sig
+
+	if err := Verify("machines", "10.1.0.1", d); err != nil {
+		t.Fatalf("expected valid signature, got: %v", err)
+	}
+}
+
+func TestVerifyRejectsTamperedValue(t *testing.T) {
+	s := newTestSigner(t)
+	d := SignedData{Value: "hello", Owner: s.ID(), Version: 1, UpdatedAt: 100}
+	d.Sig, _ = s.Sign(canonical("machines", "10.1.0.1", d))
+
+	d.Value = "tampered"
+
+	if err := Verify("machines", "10.1.0.1", d); err == nil {
+		t.Fatal("expected verification to fail for a tampered value")
+	}
+}
+
+// A signature is bound to the claimed owner: presenting it under a different
+// Owner peer.ID must not verify (this is what stops impersonation).
+func TestVerifyRejectsWrongOwner(t *testing.T) {
+	s := newTestSigner(t)
+	other := newTestSigner(t)
+
+	d := SignedData{Value: "hello", Owner: s.ID(), Version: 1, UpdatedAt: 100}
+	d.Sig, _ = s.Sign(canonical("machines", "10.1.0.1", d))
+
+	d.Owner = other.ID()
+
+	if err := Verify("machines", "10.1.0.1", d); err == nil {
+		t.Fatal("expected verification to fail when Owner != signing key")
+	}
+}

--- a/pkg/blockchain/sign_test.go
+++ b/pkg/blockchain/sign_test.go
@@ -14,63 +14,52 @@ limitations under the License.
 package blockchain
 
 import (
-	"testing"
-
 	"github.com/libp2p/go-libp2p/core/crypto"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-func newTestSigner(t *testing.T) Signer {
-	t.Helper()
+func newTestSigner() Signer {
 	priv, _, err := crypto.GenerateKeyPair(crypto.Ed25519, 0)
-	if err != nil {
-		t.Fatalf("generate key: %v", err)
-	}
+	Expect(err).NotTo(HaveOccurred())
 	s, err := NewSigner(priv)
-	if err != nil {
-		t.Fatalf("new signer: %v", err)
-	}
+	Expect(err).NotTo(HaveOccurred())
 	return s
 }
 
-func TestSignVerifyRoundTrip(t *testing.T) {
-	s := newTestSigner(t)
-	d := SignedData{Value: "hello", Owner: s.ID(), Version: 1, UpdatedAt: 100}
+var _ = Describe("Signing", func() {
+	It("round-trips a valid signature", func() {
+		s := newTestSigner()
+		d := SignedData{Value: "hello", Owner: s.ID(), Version: 1, UpdatedAt: 100}
 
-	sig, err := s.Sign(canonical("machines", "10.1.0.1", d))
-	if err != nil {
-		t.Fatalf("sign: %v", err)
-	}
-	d.Sig = sig
+		sig, err := s.Sign(canonical("machines", "10.1.0.1", d))
+		Expect(err).NotTo(HaveOccurred())
+		d.Sig = sig
 
-	if err := Verify("machines", "10.1.0.1", d); err != nil {
-		t.Fatalf("expected valid signature, got: %v", err)
-	}
-}
+		Expect(Verify("machines", "10.1.0.1", d)).To(Succeed())
+	})
 
-func TestVerifyRejectsTamperedValue(t *testing.T) {
-	s := newTestSigner(t)
-	d := SignedData{Value: "hello", Owner: s.ID(), Version: 1, UpdatedAt: 100}
-	d.Sig, _ = s.Sign(canonical("machines", "10.1.0.1", d))
+	It("rejects a tampered value", func() {
+		s := newTestSigner()
+		d := SignedData{Value: "hello", Owner: s.ID(), Version: 1, UpdatedAt: 100}
+		d.Sig, _ = s.Sign(canonical("machines", "10.1.0.1", d))
 
-	d.Value = "tampered"
+		d.Value = "tampered"
 
-	if err := Verify("machines", "10.1.0.1", d); err == nil {
-		t.Fatal("expected verification to fail for a tampered value")
-	}
-}
+		Expect(Verify("machines", "10.1.0.1", d)).NotTo(Succeed())
+	})
 
-// A signature is bound to the claimed owner: presenting it under a different
-// Owner peer.ID must not verify (this is what stops impersonation).
-func TestVerifyRejectsWrongOwner(t *testing.T) {
-	s := newTestSigner(t)
-	other := newTestSigner(t)
+	// A signature is bound to the claimed owner: presenting it under a different
+	// Owner peer.ID must not verify (this is what stops impersonation).
+	It("rejects a signature presented under a different owner", func() {
+		s := newTestSigner()
+		other := newTestSigner()
 
-	d := SignedData{Value: "hello", Owner: s.ID(), Version: 1, UpdatedAt: 100}
-	d.Sig, _ = s.Sign(canonical("machines", "10.1.0.1", d))
+		d := SignedData{Value: "hello", Owner: s.ID(), Version: 1, UpdatedAt: 100}
+		d.Sig, _ = s.Sign(canonical("machines", "10.1.0.1", d))
 
-	d.Owner = other.ID()
+		d.Owner = other.ID()
 
-	if err := Verify("machines", "10.1.0.1", d); err == nil {
-		t.Fatal("expected verification to fail when Owner != signing key")
-	}
-}
+		Expect(Verify("machines", "10.1.0.1", d)).NotTo(Succeed())
+	})
+})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -68,7 +68,19 @@ type Config struct {
 	// enable peerguardian and add specific auth options
 	PeerGuard PeerGuard
 
+	// Ownership (experimental) authenticates ledger writes so a leaked token
+	// alone no longer lets a peer overwrite another peer's entries.
+	Ownership Ownership
+
 	Whitelist []multiaddr.Multiaddr
+}
+
+// Ownership configures ledger ownership enforcement.
+// Mode is one of "off" (default), "observe" (sign + log violations) or
+// "enforce" (sign + reject unauthorized writes).
+type Ownership struct {
+	Mode string
+	TTL  time.Duration
 }
 
 type PeerGuard struct {
@@ -281,8 +293,17 @@ func (c Config) ToOpts(l log.StandardLogger) ([]node.Option, []vpn.Option, error
 	d := discovery.NewDHT(dhtOpts...)
 	m := &discovery.MDNS{}
 
+	ownershipMode := blockchain.OwnershipOff
+	switch strings.ToLower(c.Ownership.Mode) {
+	case "observe", "log", "log-only":
+		ownershipMode = blockchain.OwnershipObserve
+	case "enforce", "on":
+		ownershipMode = blockchain.OwnershipEnforce
+	}
+
 	opts := []node.Option{
 		node.ListenAddresses(c.ListenMaddrs...),
+		node.WithOwnership(ownershipMode, c.Ownership.TTL),
 		node.WithDiscoveryInterval(c.Discovery.Interval),
 		node.WithLedgerAnnounceTime(c.Ledger.AnnounceInterval),
 		node.WithLedgerInterval(c.Ledger.SyncInterval),

--- a/pkg/node/config.go
+++ b/pkg/node/config.go
@@ -76,6 +76,12 @@ type Config struct {
 
 	Sealer    Sealer
 	PeerGater Gater
+
+	// OwnershipMode selects ledger ownership enforcement (off/observe/enforce).
+	// OwnershipTTL is the liveness window after which an inactive owner's
+	// entries may be reclaimed/reaped.
+	OwnershipMode blockchain.OwnershipMode
+	OwnershipTTL  time.Duration
 }
 
 type Gater interface {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -52,6 +52,10 @@ type Node struct {
 
 const defaultChanSize = 3000
 
+// defaultOwnershipTTL is the liveness window used when ownership enforcement is
+// enabled without an explicit TTL.
+const defaultOwnershipTTL = 2 * time.Minute
+
 var defaultLibp2pOptions = []libp2p.Option{
 	libp2p.EnableNATService(),
 	libp2p.NATPortMap(),
@@ -97,7 +101,7 @@ func (e *Node) Ledger() (*blockchain.Ledger, error) {
 		return nil, err
 	}
 
-	e.ledger = blockchain.New(mw, e.config.Store)
+	e.ledger = blockchain.New(mw, e.config.Store, blockchain.WithViolationLogger(e.config.Logger.Warnf))
 	return e.ledger, nil
 }
 
@@ -166,6 +170,27 @@ func (e *Node) startNetwork(ctx context.Context) error {
 	ledger, err := e.Ledger()
 	if err != nil {
 		return err
+	}
+
+	// Once the host identity exists, install the signer and enable ledger
+	// ownership enforcement if configured. Signing is only switched on for
+	// observe/enforce modes so the default network keeps the legacy wire format.
+	if e.config.OwnershipMode != blockchain.OwnershipOff {
+		if priv := host.Peerstore().PrivKey(host.ID()); priv != nil {
+			signer, serr := blockchain.NewSigner(priv)
+			if serr != nil {
+				return fmt.Errorf("could not build ledger signer: %w", serr)
+			}
+			ttl := e.config.OwnershipTTL
+			if ttl == 0 {
+				ttl = defaultOwnershipTTL
+			}
+			ledger.SetSigner(signer)
+			ledger.SetOwnership(e.config.OwnershipMode, blockchain.DefaultRegistry(ttl), ttl)
+			e.config.Logger.Infof("ledger ownership enforcement: mode=%d ttl=%s", e.config.OwnershipMode, ttl)
+		} else {
+			e.config.Logger.Warn("ownership enforcement requested but host private key is unavailable; running unsigned")
+		}
 	}
 
 	for pid, strh := range e.config.StreamHandlers {

--- a/pkg/node/node_test.go
+++ b/pkg/node/node_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/mudler/edgevpn/pkg/blockchain"
 	"github.com/mudler/edgevpn/pkg/logger"
 	. "github.com/mudler/edgevpn/pkg/node"
+	"github.com/mudler/edgevpn/pkg/protocol"
 )
 
 var _ = Describe("Node", func() {
@@ -83,6 +84,40 @@ var _ = Describe("Node", func() {
 				}
 				return s
 			}, 240*time.Second, 1*time.Second).Should(Equal("baz"))
+		})
+
+		It("propagates owner-signed entries under ownership enforcement", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			e, _ := New(FromBase64(true, true, token, nil, nil), WithStore(&blockchain.MemoryStore{}), WithDiscoveryInterval(10*time.Second), WithOwnership(blockchain.OwnershipEnforce, 0), l)
+			e2, _ := New(FromBase64(true, true, token, nil, nil), WithStore(&blockchain.MemoryStore{}), WithDiscoveryInterval(10*time.Second), WithOwnership(blockchain.OwnershipEnforce, 0), l)
+
+			e.Start(ctx)
+			e2.Start(ctx)
+
+			ll, err := e.Ledger()
+			Expect(err).ToNot(HaveOccurred())
+			ll2, err := e2.Ledger()
+			Expect(err).ToNot(HaveOccurred())
+
+			owner := e.Host().ID().String()
+			ll.Announce(ctx, 2*time.Second, func() {
+				ll.Add(protocol.MachinesLedgerKey, map[string]interface{}{
+					"10.1.0.1": map[string]string{"PeerID": owner, "Address": "10.1.0.1"},
+				})
+			})
+
+			// e2 only accepts the entry if e's signature verifies and the value
+			// declares e as its owner — proving signing + authorized merge over p2p.
+			Eventually(func() string {
+				var m map[string]string
+				v, exists := ll2.GetKey(protocol.MachinesLedgerKey, "10.1.0.1")
+				if exists {
+					v.Unmarshal(&m)
+				}
+				return m["PeerID"]
+			}, 240*time.Second, 1*time.Second).Should(Equal(owner))
 		})
 	})
 

--- a/pkg/node/options.go
+++ b/pkg/node/options.go
@@ -175,6 +175,16 @@ func SealKeyLength(i int) func(cfg *Config) error {
 	}
 }
 
+// WithOwnership enables ledger ownership enforcement at the given mode and
+// liveness TTL (a zero ttl uses the node default).
+func WithOwnership(mode blockchain.OwnershipMode, ttl time.Duration) func(cfg *Config) error {
+	return func(cfg *Config) error {
+		cfg.OwnershipMode = mode
+		cfg.OwnershipTTL = ttl
+		return nil
+	}
+}
+
 func LibP2PLogLevel(l log.LogLevel) func(cfg *Config) error {
 	return func(cfg *Config) error {
 		log.SetAllLoggers(l)

--- a/pkg/services/alive.go
+++ b/pkg/services/alive.go
@@ -51,8 +51,17 @@ func AliveNetworkService(announcetime, scrubTime, maxtime time.Duration) node.Ne
 					t = time.Now()
 
 					if lead == n.Host().ID().String() {
-						// Automatically scrub after some time passed
-						b.DeleteBucket(protocol.HealthCheckKey)
+						if b.OwnershipEnabled() {
+							// Under ownership enforcement, reap entries of inactive
+							// owners (and stale heartbeats) instead of blindly
+							// wiping the whole healthcheck bucket. Tombstones are
+							// retained for a few liveness windows so every node
+							// observes them before they are pruned.
+							b.Reap(3 * maxtime)
+						} else {
+							// Legacy: automatically scrub after some time passed
+							b.DeleteBucket(protocol.HealthCheckKey)
+						}
 					}
 				}
 			},
@@ -71,7 +80,7 @@ func Alive(announcetime, scrubTime, maxtime time.Duration) []node.Option {
 
 // AvailableNodes returns the available nodes which sent a healthcheck in the last maxTime
 func AvailableNodes(b *blockchain.Ledger, maxTime time.Duration) (active []string) {
-	for u, t := range b.LastBlock().Storage[protocol.HealthCheckKey] {
+	for u, t := range b.CurrentData()[protocol.HealthCheckKey] {
 		var s string
 		t.Unmarshal(&s)
 		parsed, _ := time.Parse(time.RFC3339, s)

--- a/pkg/services/alive_test.go
+++ b/pkg/services/alive_test.go
@@ -69,6 +69,37 @@ var _ = Describe("Alive service", func() {
 		})
 	})
 
+	Context("Aliveness check under ownership enforcement", func() {
+		It("detects both nodes alive with signed healthchecks", func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			eopts := append(
+				Alive(5*time.Second, 100*time.Second, 15*time.Minute),
+				node.WithDiscoveryInterval(10*time.Second),
+				node.WithOwnership(blockchain.OwnershipEnforce, 15*time.Minute),
+				node.FromBase64(true, true, token, nil, nil),
+				l)
+
+			e1, _ := node.New(append(eopts, node.WithStore(&blockchain.MemoryStore{}))...)
+			e2, _ := node.New(append(eopts, node.WithStore(&blockchain.MemoryStore{}))...)
+
+			e1.Start(ctx)
+			e2.Start(ctx)
+
+			matches := And(ContainElement(e2.Host().ID().String()),
+				ContainElement(e1.Host().ID().String()))
+
+			Eventually(func() []string {
+				ll, err := e1.Ledger()
+				if err != nil {
+					return []string{}
+				}
+				return AvailableNodes(ll, 15*time.Minute)
+			}, 120*time.Second, 1*time.Second).Should(matches)
+		})
+	})
+
 	Context("Aliveness Scrub", func() {
 		BeforeEach(func() {
 			opts = append(

--- a/pkg/services/files.go
+++ b/pkg/services/files.go
@@ -145,6 +145,13 @@ func ReceiveFile(ctx context.Context, ledger *blockchain.Ledger, n *node.Node, l
 					return errors.New("file not found")
 				}
 
+				// Don't pull a file from an owner that has gone inactive (no-op
+				// when ownership enforcement is disabled).
+				if !ledger.IsOwnerLive(fi.PeerID) {
+					l.Debug("file owner inactive, retrying in 5 seconds")
+					continue
+				}
+
 				// Decode the Peer
 				d, err := peer.Decode(fi.PeerID)
 				if err != nil {

--- a/pkg/services/files.go
+++ b/pkg/services/files.go
@@ -145,13 +145,6 @@ func ReceiveFile(ctx context.Context, ledger *blockchain.Ledger, n *node.Node, l
 					return errors.New("file not found")
 				}
 
-				// Don't pull a file from an owner that has gone inactive (no-op
-				// when ownership enforcement is disabled).
-				if !ledger.IsOwnerLive(fi.PeerID) {
-					l.Debug("file owner inactive, retrying in 5 seconds")
-					continue
-				}
-
 				// Decode the Peer
 				d, err := peer.Decode(fi.PeerID)
 				if err != nil {

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -150,13 +150,6 @@ func ConnectNetworkService(announcetime time.Duration, serviceID string, srcaddr
 						return
 					}
 
-					// Don't dial a service whose owner has gone inactive (no-op
-					// when ownership enforcement is disabled).
-					if !ledger.IsOwnerLive(service.PeerID) {
-						conn.Close()
-						return
-					}
-
 					// Decode the Peer
 					d, err := peer.Decode(service.PeerID)
 					if err != nil {

--- a/pkg/services/services.go
+++ b/pkg/services/services.go
@@ -150,6 +150,13 @@ func ConnectNetworkService(announcetime time.Duration, serviceID string, srcaddr
 						return
 					}
 
+					// Don't dial a service whose owner has gone inactive (no-op
+					// when ownership enforcement is disabled).
+					if !ledger.IsOwnerLive(service.PeerID) {
+						conn.Close()
+						return
+					}
+
 					// Decode the Peer
 					d, err := peer.Decode(service.PeerID)
 					if err != nil {

--- a/pkg/vpn/dhcp.go
+++ b/pkg/vpn/dhcp.go
@@ -75,7 +75,7 @@ func DHCPNetworkService(ip chan string, l log.StandardLogger, maxTime time.Durat
 			currentIPs := map[string]string{}
 			ips := []string{}
 
-			for _, t := range b.LastBlock().Storage[protocol.MachinesLedgerKey] {
+			for _, t := range b.CurrentData()[protocol.MachinesLedgerKey] {
 				var m types.Machine
 				t.Unmarshal(&m)
 				currentIPs[m.PeerID] = m.Address

--- a/pkg/vpn/vpn.go
+++ b/pkg/vpn/vpn.go
@@ -237,6 +237,12 @@ func handleFrame(mgr streamManager, frame ethernet.Frame, c *Config, n *node.Nod
 		machine := &types.Machine{}
 		value.Unmarshal(machine)
 
+		// Don't route to an owner that has gone inactive (under ownership
+		// enforcement); this is a no-op when enforcement is disabled.
+		if !ledger.IsOwnerLive(machine.PeerID) {
+			return notFoundErr
+		}
+
 		// Decode the Peer
 		d, err = peer.Decode(machine.PeerID)
 	}


### PR DESCRIPTION
Closes the audit's "any token holder can rewrite anything" class of issues by making ledger writes authenticated and ownership-bound, gated behind an opt-in flag so existing networks are unchanged by default.

Core model (docs/design/authenticated-ledger.md):
- SignedData: each entry carries Owner (peer.ID), monotonic Version, UpdatedAt and an Ed25519 Sig over a canonical encoding. Verification recovers the key from the Owner peer.ID (libp2p Ed25519 identities embed it) — no PKI.
- Policy registry (policy.go): single source of truth for which buckets are owned and how they expire (Liveness vs Absolute TTL). Adding a bucket is one line. machines/services/files/users/healthcheck are registered.
- Authorized merge: Update runs a per-key merge under enforcement — verify sig, require value-owner == signer, reject cross-owner overwrite of a live entry (anti-hijack), reject lower Version (anti-rollback/replay), signed tombstones for deletes. Cross-owner writes allowed only once the owner's lease expires (powers both reclaim and reaping).
- Reaper (reaper.go): leader-elected, registry-driven; tombstones entries of inactive owners and prunes old tombstones so the ledger stays bounded. Wired into the alive service's leader path, replacing the blunt healthcheck scrub.

Modes & compatibility:
- --ownership=off|observe|enforce (+ --ownership-ttl). Default off keeps the exact legacy bare-value wire format and height-wins Update (back-compat). observe = sign + log violations; enforce = sign + reject.
- Custom JSON keeps unsigned entries on the legacy wire; readers (GetKey/ Exists/CurrentData) still see plain values and hide tombstones, so callers are unchanged.

Tests: sign round-trip/tamper/wrong-owner, policy/IsLive, merge (owner write, hijack-rejected, rollback-rejected, forged-sig, reclaim-after-expiry, tombstone), JSON wire compat, reaper; plus an enforce-mode end-to-end node test over real libp2p. Full existing suite (node/services/trustzone) still green.

Follow-ups (documented): DNS bucket ownership (record needs an owner field), inlined reader-side IsLive guards.